### PR TITLE
Critical cache nil pointer access bug fix

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -21,9 +21,9 @@ func (c cache) Get(key string) ([]byte, bool) {
 	val := c.c.Get(key)
 	if val != nil {
 		return val.Value(), true
-	} else {
-		return nil, false
 	}
+
+	return nil, false
 }
 
 func (c cache) Set(key string, val []byte) {

--- a/cache.go
+++ b/cache.go
@@ -19,7 +19,11 @@ type cache struct {
 
 func (c cache) Get(key string) ([]byte, bool) {
 	val := c.c.Get(key)
-	return val.Value(), val != nil
+	if val != nil {
+		return val.Value(), true
+	} else {
+		return nil, false
+	}
 }
 
 func (c cache) Set(key string, val []byte) {


### PR DESCRIPTION
I've been using this project for a big school project for quite some time, very nifty ! 

However, I encountered a critical sigsev, it happens as soon as a cache value is not already cached.

From quick debugging and understanding of the code base and the library used here is what I came up with:

goldmark-pdf uses ttlcache which has it's Item.Value() now implemented as such:

```go
func (item *Item[K, V]) Value() V {
	item.mu.RLock()
	defer item.mu.RUnlock()

	return item.value
}
```
In which case, when item is nil, you will have a sigsev on item.mu.RLock().


The cache.Get() in goldmark-pdf is implemented as such:
```go
func (c cache) Get(key string) ([]byte, bool) {
       val := c.c.Get(key)
       return val.Value(), val != nil
}
```

So it will sigsev as soon as val is nil (not cached yet) and tries to return the []byte return vabue.

Quick fix with this PR.