### PR TITLE
Implement auto-width column sizes for tables

### DIFF
--- a/pdf_test.go
+++ b/pdf_test.go
@@ -1,0 +1,63 @@
+package pdf
+
+import "io"
+
+// MockPdf implements the PDF interface for testing
+type MockPdf struct {
+	pageWidth   float64
+	pageHeight  float64
+	leftMargin  float64
+	rightMargin float64
+}
+
+func (m *MockPdf) AddInternalLink(anchor string) {}
+func (m *MockPdf) AddPage()                      {}
+func (m *MockPdf) BR(h float64)                  {}
+func (m *MockPdf) CellFormat(w, h float64, txt, border string, ln int, align string, fill bool, link int, linkStr string) {
+}
+func (m *MockPdf) GetMargins() (left, top, right, bottom float64) {
+	return m.leftMargin, 10, m.rightMargin, 10
+}
+func (m *MockPdf) GetPageSize() (width, height float64) {
+	return m.pageWidth, m.pageHeight
+}
+func (m *MockPdf) GetX() float64               { return 0 }
+func (m *MockPdf) GetY() float64               { return 0 }
+func (m *MockPdf) Line(x1, x2, y1, y2 float64) {}
+func (m *MockPdf) MeasureTextWidth(s string) float64 {
+	// Simple approximation: each character is 5 units wide
+	return float64(len(s)) * 5.0
+}
+func (m *MockPdf) RegisterImage(id, format string, src io.Reader)  {}
+func (m *MockPdf) SetDrawColor(r, g, b uint8)                      {}
+func (m *MockPdf) SetFillColor(r, g, b uint8)                      {}
+func (m *MockPdf) SetFont(family, style string, size int) error    { return nil }
+func (m *MockPdf) AddFont(family, style string, data []byte) error { return nil }
+func (m *MockPdf) SetLineWidth(width float64)                      {}
+func (m *MockPdf) SetMarginLeft(margin float64)                    {}
+func (m *MockPdf) SetMarginRight(margin float64)                   {}
+func (m *MockPdf) SetTextColor(r, g, b uint8)                      {}
+func (m *MockPdf) SetX(x float64)                                  {}
+func (m *MockPdf) SetY(y float64)                                  {}
+func (m *MockPdf) SplitText(txt string, w float64) []string {
+	// Simple implementation for testing
+	if m.MeasureTextWidth(txt) <= w {
+		return []string{txt}
+	}
+	// Split into chunks
+	charsPerLine := int(w / 5.0) // 5 units per character
+	var lines []string
+	for i := 0; i < len(txt); i += charsPerLine {
+		end := i + charsPerLine
+		if end > len(txt) {
+			end = len(txt)
+		}
+		lines = append(lines, txt[i:end])
+	}
+	return lines
+}
+func (m *MockPdf) UseImage(id string, x, y, w, h float64)                           {}
+func (m *MockPdf) Write(w io.Writer) error                                          { return nil }
+func (m *MockPdf) WriteText(h float64, txtStr string)                               {}
+func (m *MockPdf) WriteInternalLink(lineHeight float64, text string, anchor string) {}
+func (m *MockPdf) WriteExternalLink(lineHeight float64, text, destination string)   {}

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -645,6 +645,11 @@ func (r *nodeRederFuncs) renderTaskCheckBox(w *Writer, source []byte, node ast.N
 func (r *nodeRederFuncs) renderTable(w *Writer, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
 		w.LogDebug("Table (entering)", "")
+
+		currentTableData = CollectTableData(w, source, node)
+		cellwidths = CalculateOptimalColumnWidths(w, currentTableData)
+		w.LogDebug("Table column widths calculated", fmt.Sprintf("Column widths: %v", cellwidths))
+
 		x := &state{
 			containerType: east.KindTable,
 			textStyle:     *w.Styles.THeader, listkind: notlist,
@@ -664,6 +669,9 @@ func (r *nodeRederFuncs) renderTable(w *Writer, source []byte, node ast.Node, en
 		w.States.pop()
 		w.LogDebug("Table (leaving)", "")
 		w.Pdf.BR(w.States.peek().textStyle.Size + w.States.peek().textStyle.Spacing)
+
+		currentTableData = nil
+		curdatacell = 0
 	}
 
 	return ast.WalkContinue, nil
@@ -678,7 +686,6 @@ func (r *nodeRederFuncs) renderTableHeader(w *Writer, source []byte, node ast.No
 			leftMargin: w.States.peek().leftMargin, isHeader: true,
 		}
 		w.States.push(x)
-		cellwidths = make([]float64, 0)
 	} else {
 		w.States.pop()
 		w.LogDebug("TableHead (leaving)", "")

--- a/table.go
+++ b/table.go
@@ -1,0 +1,167 @@
+package pdf
+
+import (
+	"bytes"
+	"github.com/yuin/goldmark/ast"
+	east "github.com/yuin/goldmark/extension/ast"
+)
+
+// TableData stores the content of a table for width calculation
+type TableData struct {
+	Headers []string
+	Rows    [][]string
+}
+
+var currentTableData *TableData
+
+// ExtractCellText recursively extracts all text content from a cell
+func ExtractCellText(source []byte, node ast.Node) string {
+	var buf bytes.Buffer
+
+	ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		switch n.Kind() {
+		case ast.KindText:
+			textNode := n.(*ast.Text)
+			buf.Write(textNode.Segment.Value(source))
+		case ast.KindString:
+			stringNode := n.(*ast.String)
+			buf.Write(stringNode.Value)
+		}
+
+		return ast.WalkContinue, nil
+	})
+
+	return buf.String()
+}
+
+// CollectTableData walks through table nodes to collect cell data
+func CollectTableData(w *Writer, source []byte, node ast.Node) *TableData {
+	tData := TableData{
+		Headers: make([]string, 0),
+		Rows:    make([][]string, 0),
+	}
+
+	if _, ok := node.(*east.Table); !ok {
+		w.LogDebug("CollectTableData", "(not table)")
+		return &tData
+	}
+
+	var extract func(w *Writer, source []byte, n ast.Node, inHeader bool)
+	extract = func(w *Writer, source []byte, n ast.Node, inHeader bool) {
+		switch n.Kind() {
+		case east.KindTableHeader:
+			for cell := n.FirstChild(); cell != nil; cell = cell.NextSibling() {
+				if cell.Kind() == east.KindTableCell {
+					tData.Headers = append(tData.Headers, ExtractCellText(source, cell))
+				}
+			}
+		case east.KindTableRow:
+			var row []string
+			for cell := n.FirstChild(); cell != nil; cell = cell.NextSibling() {
+				if cell.Kind() == east.KindTableCell {
+					row = append(row, ExtractCellText(source, cell))
+				}
+			}
+			tData.Rows = append(tData.Rows, row)
+		default:
+			for child := n.FirstChild(); child != nil; child = child.NextSibling() {
+				extract(w, source, child, inHeader)
+			}
+		}
+	}
+
+	// start extraction from table's children
+	for child := node.FirstChild(); child != nil; child = child.NextSibling() {
+		extract(w, source, child, false)
+	}
+
+	return &tData
+}
+
+// CalculateOptimalColumnWidths based on content
+func CalculateOptimalColumnWidths(w *Writer, tableData *TableData) []float64 {
+	if tableData == nil {
+		return []float64{}
+	}
+
+	// Determine number of columns from headers or first row
+	numCols := len(tableData.Headers)
+	if numCols == 0 && len(tableData.Rows) > 0 {
+		numCols = len(tableData.Rows[0])
+	}
+
+	if numCols == 0 {
+		return []float64{}
+	}
+	minWidths := make([]float64, numCols)
+	maxWidths := make([]float64, numCols)
+
+	// Get page dimensions
+	pageWidth, _ := w.Pdf.GetPageSize()
+	marginLeft, _, marginRight, _ := w.Pdf.GetMargins()
+	availableWidth := pageWidth - marginLeft - marginRight
+
+	// Calculate minimum widths based on headers
+	if len(tableData.Headers) > 0 {
+		for i, header := range tableData.Headers {
+			minWidths[i] = w.Pdf.MeasureTextWidth(header) + (2 * w.Pdf.MeasureTextWidth("m"))
+			maxWidths[i] = minWidths[i]
+		}
+	} else {
+		// No headers, use a default minimum width
+		defaultWidth := w.Pdf.MeasureTextWidth("mmmm")
+		for i := 0; i < numCols; i++ {
+			minWidths[i] = defaultWidth
+			maxWidths[i] = defaultWidth
+		}
+	}
+
+	// Calculate maximum widths based on content
+	for _, row := range tableData.Rows {
+		for i, cell := range row {
+			if i < numCols {
+				cellWidth := w.Pdf.MeasureTextWidth(cell) + (2 * w.Pdf.MeasureTextWidth("m"))
+				if cellWidth > maxWidths[i] {
+					maxWidths[i] = cellWidth
+				}
+			}
+		}
+	}
+
+	// Calculate total minimum and maximum widths
+	totalMin := 0.0
+	totalMax := 0.0
+	for i := 0; i < numCols; i++ {
+		totalMin += minWidths[i]
+		totalMax += maxWidths[i]
+	}
+
+	// Determine final column widths
+	finalWidths := make([]float64, numCols)
+
+	if totalMax <= availableWidth {
+		// All columns can have their maximum width
+		copy(finalWidths, maxWidths)
+	} else if totalMin > availableWidth {
+		// if minimum widths exceed available space, distribute proportionally
+		ratio := availableWidth / totalMin
+		for i := 0; i < numCols; i++ {
+			finalWidths[i] = minWidths[i] * ratio
+		}
+	} else {
+		// Distribute extra space proportionally
+		extraSpace := availableWidth - totalMin
+		maxExtraSpace := totalMax - totalMin
+
+		for i := 0; i < numCols; i++ {
+			proportion := (maxWidths[i] - minWidths[i]) / maxExtraSpace
+			finalWidths[i] = minWidths[i] + (extraSpace * proportion)
+		}
+	}
+
+	return finalWidths
+}

--- a/table_test.go
+++ b/table_test.go
@@ -1,0 +1,163 @@
+package pdf
+
+import (
+	"testing"
+)
+
+func TestCalculateOptimalColumnWidths(t *testing.T) {
+	tests := []struct {
+		name           string
+		pageWidth      float64
+		leftMargin     float64
+		rightMargin    float64
+		tableData      *TableData
+		expectedWidths []float64
+	}{
+		{
+			name:           "Empty table",
+			pageWidth:      600,
+			leftMargin:     50,
+			rightMargin:    50,
+			tableData:      nil,
+			expectedWidths: []float64{},
+		},
+		{
+			name:        "Table with headers only",
+			pageWidth:   600,
+			leftMargin:  50,
+			rightMargin: 50,
+			tableData: &TableData{
+				Headers: []string{"Name", "Age", "City"},
+				Rows:    [][]string{},
+			},
+			expectedWidths: []float64{30, 25, 30}, // 4*5+10, 3*5+10, 4*5+10
+		},
+		{
+			name:        "Table with headers and short content",
+			pageWidth:   600,
+			leftMargin:  50,
+			rightMargin: 50,
+			tableData: &TableData{
+				Headers: []string{"Name", "Age", "City"},
+				Rows: [][]string{
+					{"John", "30", "NYC"},
+					{"Jane", "25", "LA"},
+				},
+			},
+			expectedWidths: []float64{30, 25, 30}, // Headers are wider than content
+		},
+		{
+			name:        "Table with headers and long content",
+			pageWidth:   600,
+			leftMargin:  50,
+			rightMargin: 50,
+			tableData: &TableData{
+				Headers: []string{"Name", "Age", "City"},
+				Rows: [][]string{
+					{"Alexander Hamilton", "30", "New York City"},
+					{"George Washington", "57", "Mount Vernon, Virginia"},
+				},
+			},
+			expectedWidths: []float64{100, 25, 120}, // 18*5+10, 3*5+10, 22*5+10
+		},
+		{
+			name:        "Table without headers",
+			pageWidth:   600,
+			leftMargin:  50,
+			rightMargin: 50,
+			tableData: &TableData{
+				Headers: []string{},
+				Rows: [][]string{
+					{"John", "30", "NYC"},
+					{"Jane", "25", "LA"},
+				},
+			},
+			expectedWidths: []float64{30, 20, 25}, // 4*5+10, 2*5+10, 3*5+10
+		},
+		{
+			name:        "Table with content exceeding page width",
+			pageWidth:   300,
+			leftMargin:  50,
+			rightMargin: 50,
+			tableData: &TableData{
+				Headers: []string{"Very Long Header Name", "Another Long Header", "Third Long Header"},
+				Rows: [][]string{
+					{"This is a very long cell content", "Another long content here", "More long content"},
+				},
+			},
+			expectedWidths: []float64{73.02, 66.67, 60.32}, // Distributed proportionally based on content
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockPdf := &MockPdf{
+				pageWidth:   tt.pageWidth,
+				pageHeight:  800,
+				leftMargin:  tt.leftMargin,
+				rightMargin: tt.rightMargin,
+			}
+
+			writer := &Writer{
+				Pdf: mockPdf,
+			}
+
+			widths := CalculateOptimalColumnWidths(writer, tt.tableData)
+
+			if len(widths) != len(tt.expectedWidths) {
+				t.Errorf("Expected %d widths, got %d", len(tt.expectedWidths), len(widths))
+				return
+			}
+
+			for i, w := range widths {
+				// Allow small floating point differences
+				if diff := w - tt.expectedWidths[i]; diff < -0.01 || diff > 0.01 {
+					t.Errorf("Column %d: expected width %.2f, got %.2f", i, tt.expectedWidths[i], w)
+				}
+			}
+		})
+	}
+}
+
+func TestCalculateOptimalColumnWidths_EdgeCases(t *testing.T) {
+	mockPdf := &MockPdf{
+		pageWidth:   600,
+		pageHeight:  800,
+		leftMargin:  50,
+		rightMargin: 50,
+	}
+
+	writer := &Writer{
+		Pdf: mockPdf,
+	}
+
+	// Test with mismatched row lengths
+	tableData := &TableData{
+		Headers: []string{"Col1", "Col2", "Col3"},
+		Rows: [][]string{
+			{"A", "B"},           // Missing third column
+			{"C", "D", "E", "F"}, // Extra column
+		},
+	}
+
+	widths := CalculateOptimalColumnWidths(writer, tableData)
+
+	// Should handle gracefully and return 3 columns based on headers
+	if len(widths) != 3 {
+		t.Errorf("Expected 3 widths for 3 headers, got %d", len(widths))
+	}
+
+	// Test proportional distribution
+	tableData2 := &TableData{
+		Headers: []string{"Small", "Medium Header", "Very Large Header Name"},
+		Rows:    [][]string{},
+	}
+
+	widths2 := CalculateOptimalColumnWidths(writer, tableData2)
+
+	// The third column should be wider than the second, which should be wider than the first
+	if widths2[0] >= widths2[1] || widths2[1] >= widths2[2] {
+		t.Errorf("Expected widths to be proportional to header lengths: %.2f, %.2f, %.2f",
+			widths2[0], widths2[1], widths2[2])
+	}
+}


### PR DESCRIPTION
Fixes #23 by adding new functions to parse the table content before rendering and calculate column sizes using all content instead of just relying on header values.

- If minimum widths exceed page width, allocate proportionally and rely on line breaks (content only)
- Content that doesn't fit creates a new line and wraps
- Add some tests for column computations

### Before
<img width="546" height="103" alt="Screenshot_2025-07-29_15-00-25" src="https://github.com/user-attachments/assets/25728dd2-2e5e-4794-9df2-dfd647bd6eb7" />

<img width="655" height="183" alt="Screenshot_2025-07-29_15-00-49" src="https://github.com/user-attachments/assets/aa9e6e91-f224-4079-bcc8-8bab9805d3d0" />

### After
<img width="629" height="95" alt="Screenshot_2025-07-29_15-07-37" src="https://github.com/user-attachments/assets/11ec62a1-369b-4522-9c83-cc23c8cdb960" />

<img width="660" height="173" alt="Screenshot_2025-07-29_15-08-06" src="https://github.com/user-attachments/assets/c2251ac5-722f-4027-946c-c472632b19c8" />

*Screenshots are clipped near the page margins.*