### PR TITLE
Allow disabling of html character escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ goldmark.New(
             pdf.WithHeadingFont(pdf.GetTextFont("IBM Plex Serif", pdf.FontLora)),
             pdf.WithBodyFont(pdf.GetTextFont("Open Sans", pdf.FontRoboto)),
             pdf.WithCodeFont(pdf.GetCodeFont("Inconsolata", pdf.FontRobotoMono)),
+            pdf.WithEscapeHTML(false), // default: true
         ),
+    ),
+    goldmark.WithRendererOptions(
+        html.WithUnsafe(), // for compatibility if WithEscapeHTML() is not used
     ),
 )
 ```

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package pdf
 
 import (
 	"context"
+	goldrender "github.com/yuin/goldmark/renderer"
 	"io"
 	"net/http"
 	"os"
@@ -11,6 +12,7 @@ import (
 )
 
 type Config struct {
+	goldrender.Config
 	Context context.Context
 
 	PDF PDF
@@ -35,6 +37,7 @@ func DefaultConfig() *Config {
 	c.Context = context.Background()
 	c.ImageFS = http.FS(os.DirFS("."))
 	c.Styles = DefaultStyles()
+	c.Options = make(map[goldrender.OptionName]interface{})
 
 	return c
 }

--- a/fpdf.go
+++ b/fpdf.go
@@ -12,7 +12,7 @@ type FpdfConfig struct {
 	Title   string
 	Subject string
 
-	Orientation string // Default Portriat
+	Orientation string // Default Portrait
 	PaperSize   string // Default A4
 
 	Logo       io.Reader

--- a/option.go
+++ b/option.go
@@ -2,6 +2,7 @@ package pdf
 
 import (
 	"context"
+	goldrender "github.com/yuin/goldmark/renderer"
 	"image/color"
 	"io"
 	"net/http"
@@ -9,6 +10,13 @@ import (
 	"github.com/alecthomas/chroma/v2"
 	"github.com/go-swiss/fonts"
 	"github.com/yuin/goldmark/util"
+)
+
+const (
+	// Same internal opt name as html.WithUnsafe() from goldmark
+	// https://github.com/yuin/goldmark/blob/master/renderer/html/html.go#L221
+	optUnsafe     goldrender.OptionName = "Unsafe"
+	optEscapeHTML goldrender.OptionName = "EscapeHTML"
 )
 
 // An Option interface is a functional option type for the Renderer.
@@ -63,6 +71,13 @@ func WithLinkColor(val color.Color) Option {
 func WithTraceWriter(val io.Writer) Option {
 	return OptionFunc(func(c *Config) {
 		c.TraceWriter = val
+	})
+}
+
+// If the content should escape HTML looking characters
+func WithEscapeHTML(val bool) Option {
+	return OptionFunc(func(c *Config) {
+		c.Options[optEscapeHTML] = val
 	})
 }
 


### PR DESCRIPTION
Add ability to turn off html escaping. Current implementation is similar to html renderer from upstream goldmark and escapes by default.

**Note: I intentionally left default to escape since this was previous behavior. (Although arguably doesn't really make sense in PDFs)**

### Before
<img width="297" height="56" alt="Screenshot_2025-07-30_02-09-48" src="https://github.com/user-attachments/assets/6e7c9884-ae26-46b3-8e3c-e4eb897a446e" />

### After
<img width="254" height="52" alt="Screenshot_2025-07-30_02-12-08" src="https://github.com/user-attachments/assets/68affd01-1857-4044-a47b-1b14e347a72e" />

---

Fixes #17