### PR TITLE
Fix lint issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
     - name: Run tests
@@ -29,10 +29,10 @@ jobs:
     
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: 'stable'
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@v9

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+# https://golangci-lint.run/usage/configuration/
+version: "2"
+
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+        - os.Remove
+        - os.RemoveAll

--- a/fs.go
+++ b/fs.go
@@ -34,7 +34,7 @@ func getFileMime(f http.File) string {
 		return ""
 	}
 
-	f.Seek(0, io.SeekStart)
+	_, _ = f.Seek(0, io.SeekStart)
 	return mime.TypeByExtension(http.DetectContentType(sniff))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stephenafamo/goldmark-pdf
 
-go 1.23.0
+go 1.24.0
 
 retract v0.3.0 // Wrong implementation of default cache
 

--- a/gopdf/gopdf.go
+++ b/gopdf/gopdf.go
@@ -13,9 +13,10 @@ type Impl struct {
 	Height float64
 	GoPdf  *gopdf.GoPdf
 
-	textR, textG, textB       uint8
+	// TODO: remove these unused color fields once it's confirmed nothing relies on them.
+	textR, textG, textB       uint8 //nolint:unused
 	fillR, fillG, fillB       uint8
-	strokeR, strokeG, strokeB uint8
+	strokeR, strokeG, strokeB uint8 //nolint:unused
 }
 
 func (f Impl) maybeAddPage(lineHeight float64) {
@@ -70,8 +71,7 @@ func (f Impl) SetMarginTop(margin float64) {
 }
 
 func (f Impl) SetFont(family string, style string, size int) error {
-	f.GoPdf.SetFont(family, style, size)
-	return nil
+	return f.GoPdf.SetFont(family, style, size)
 }
 
 // Writing
@@ -226,18 +226,20 @@ func (f Impl) SplitText(text string, width float64) []string {
 }
 
 // Colors
+// TODO: value receivers make these field assignments ineffective; switch to pointer
+// receivers (or drop the fields) once the dependent code paths are verified.
 func (f Impl) SetDrawColor(r uint8, g uint8, b uint8) {
-	f.strokeR, f.strokeB, f.strokeG = r, g, b
+	f.strokeR, f.strokeB, f.strokeG = r, g, b //nolint:staticcheck // SA4005: see TODO above
 	f.GoPdf.SetStrokeColor(r, g, b)
 }
 
 func (f Impl) SetFillColor(r uint8, g uint8, b uint8) {
-	f.fillR, f.fillB, f.fillG = r, g, b
+	f.fillR, f.fillB, f.fillG = r, g, b //nolint:staticcheck // SA4005: see TODO above
 	f.GoPdf.SetFillColor(r, g, b)
 }
 
 func (f Impl) SetTextColor(r uint8, g uint8, b uint8) {
-	f.textR, f.textB, f.textG = r, g, b
+	f.textR, f.textB, f.textG = r, g, b //nolint:staticcheck // SA4005: see TODO above
 	f.GoPdf.SetTextColor(r, g, b)
 }
 
@@ -251,7 +253,8 @@ func (f Impl) Line(x1 float64, y1 float64, x2 float64, y2 float64) {
 }
 
 func (f Impl) Write(w io.Writer) error {
-	return f.GoPdf.Write(w)
+	_, err := f.GoPdf.WriteTo(w)
+	return err
 }
 
 func (f Impl) GetMargins() (left, top, right, bottom float64) {
@@ -272,8 +275,7 @@ func (f Impl) AddFont(family string, styleStr string, data []byte) error {
 		style = style | gopdf.Underline
 	}
 
-	f.GoPdf.AddTTFFontDataWithOption(family, data, gopdf.TtfOption{
+	return f.GoPdf.AddTTFFontDataWithOption(family, data, gopdf.TtfOption{
 		Style: style,
 	})
-	return nil
 }

--- a/renderer.go
+++ b/renderer.go
@@ -133,7 +133,7 @@ func SetStyle(pdf PDF, s Style) {
 	textR, textG, textB, _ := s.TextColor.RGBA()
 	fillR, fillG, fillB, _ := s.FillColor.RGBA()
 
-	pdf.SetFont(s.Font.Family, s.format, int(s.Size))
+	_ = pdf.SetFont(s.Font.Family, s.format, int(s.Size))
 	pdf.SetTextColor(uint8(textR>>8), uint8(textG>>8), uint8(textB>>8))
 	pdf.SetFillColor(uint8(fillR>>8), uint8(fillG>>8), uint8(fillB>>8))
 	pdf.SetDrawColor(uint8(fillR>>8), uint8(fillG>>8), uint8(fillB>>8))

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -587,21 +587,21 @@ func (r *nodeRederFuncs) renderEmphasis(w *Writer, source []byte, node ast.Node,
 		switch n.Level {
 		case 2:
 			w.LogDebug("Strong (entering)", "")
-			w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "B", "", -1)
+			w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "B", "")
 			w.States.peek().textStyle.format += "B"
 		default:
 			w.LogDebug("Emph (entering)", "")
-			w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "I", "", -1)
+			w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "I", "")
 			w.States.peek().textStyle.format += "I"
 		}
 	} else {
 		switch n.Level {
 		case 2:
 			w.LogDebug("Strong (leaving)", "")
-			w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "B", "", -1)
+			w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "B", "")
 		default:
 			w.LogDebug("Emph (leaving)", "")
-			w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "I", "", -1)
+			w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "I", "")
 		}
 	}
 
@@ -614,7 +614,7 @@ func (r *nodeRederFuncs) renderStrikethrough(w *Writer, source []byte, node ast.
 		w.States.peek().textStyle.format += "S"
 	} else {
 		w.LogDebug("Strike (leaving)", "")
-		w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "S", "", -1)
+		w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "S", "")
 	}
 
 	return ast.WalkContinue, nil
@@ -743,7 +743,7 @@ func (r *nodeRederFuncs) renderTableCell(w *Writer, source []byte, node ast.Node
 		}
 		w.States.push(x)
 
-		w.WriteText(string(n.Text(source)))
+		w.WriteText(ExtractCellText(source, n))
 	} else {
 		w.States.pop()
 		w.LogDebug("TableCell (leaving)", "")

--- a/table.go
+++ b/table.go
@@ -18,7 +18,7 @@ var currentTableData *TableData
 func ExtractCellText(source []byte, node ast.Node) string {
 	var buf bytes.Buffer
 
-	ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+	_ = ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}

--- a/writer.go
+++ b/writer.go
@@ -31,7 +31,7 @@ type Writer struct {
 func (r *Writer) LogDebug(source, msg string) {
 	if r.DebugWriter != nil {
 		indent := strings.Repeat("-", len(r.States.stack)-1)
-		r.DebugWriter.Write([]byte(fmt.Sprintf("%v[%v] %v\n", indent, source, msg)))
+		_, _ = fmt.Fprintf(r.DebugWriter, "%v[%v] %v\n", indent, source, msg)
 	}
 }
 
@@ -99,7 +99,7 @@ func (w *Writer) WriteText(stringContents string) {
 		escapeWriter{escapeHTML: w.EscapeHTML}.write(bufw, []byte(stringContents))
 	}
 
-	bufw.Flush()
+	_ = bufw.Flush()
 	w.Text(currentStyle, bb.String())
 }
 


### PR DESCRIPTION
Also switch a few function calls to use non-deprecated variants.

Left some `TODO` with comments to remove potential dead code in another cleanup pass in case other improvements were planning on using the variables.

Also bump minimum go version to `1.24.0`.