### PR TITLE
Fix #31 table multi line cells

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
     - name: Run tests
@@ -29,10 +29,10 @@ jobs:
     
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Install go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: 'stable'
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v8
+      uses: golangci/golangci-lint-action@v9

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+# https://golangci-lint.run/usage/configuration/
+version: "2"
+
+linters:
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+        - os.Remove
+        - os.RemoveAll

--- a/constants.go
+++ b/constants.go
@@ -14,8 +14,13 @@ const (
 // in the table body as well.
 var cellwidths []float64
 
+// Per-body-row wrapped line counts. Indexed by body-row position, matching
+// curTableRow in the renderer.
+var cellMaxLines []int
+
 var (
-	curdatacell int
+	curTableCol int
+	curTableRow int
 	fill        = false
 )
 

--- a/fs.go
+++ b/fs.go
@@ -34,7 +34,7 @@ func getFileMime(f http.File) string {
 		return ""
 	}
 
-	f.Seek(0, io.SeekStart)
+	_, _ = f.Seek(0, io.SeekStart)
 	return mime.TypeByExtension(http.DetectContentType(sniff))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stephenafamo/goldmark-pdf
 
-go 1.23.0
+go 1.24.0
 
 retract v0.3.0 // Wrong implementation of default cache
 

--- a/gopdf/gopdf.go
+++ b/gopdf/gopdf.go
@@ -13,9 +13,10 @@ type Impl struct {
 	Height float64
 	GoPdf  *gopdf.GoPdf
 
-	textR, textG, textB       uint8
+	// TODO: remove these unused color fields once it's confirmed nothing relies on them.
+	textR, textG, textB       uint8 //nolint:unused
 	fillR, fillG, fillB       uint8
-	strokeR, strokeG, strokeB uint8
+	strokeR, strokeG, strokeB uint8 //nolint:unused
 }
 
 func (f Impl) maybeAddPage(lineHeight float64) {
@@ -70,8 +71,7 @@ func (f Impl) SetMarginTop(margin float64) {
 }
 
 func (f Impl) SetFont(family string, style string, size int) error {
-	f.GoPdf.SetFont(family, style, size)
-	return nil
+	return f.GoPdf.SetFont(family, style, size)
 }
 
 // Writing
@@ -226,18 +226,20 @@ func (f Impl) SplitText(text string, width float64) []string {
 }
 
 // Colors
+// TODO: value receivers make these field assignments ineffective; switch to pointer
+// receivers (or drop the fields) once the dependent code paths are verified.
 func (f Impl) SetDrawColor(r uint8, g uint8, b uint8) {
-	f.strokeR, f.strokeB, f.strokeG = r, g, b
+	f.strokeR, f.strokeB, f.strokeG = r, g, b //nolint:staticcheck // SA4005: see TODO above
 	f.GoPdf.SetStrokeColor(r, g, b)
 }
 
 func (f Impl) SetFillColor(r uint8, g uint8, b uint8) {
-	f.fillR, f.fillB, f.fillG = r, g, b
+	f.fillR, f.fillB, f.fillG = r, g, b //nolint:staticcheck // SA4005: see TODO above
 	f.GoPdf.SetFillColor(r, g, b)
 }
 
 func (f Impl) SetTextColor(r uint8, g uint8, b uint8) {
-	f.textR, f.textB, f.textG = r, g, b
+	f.textR, f.textB, f.textG = r, g, b //nolint:staticcheck // SA4005: see TODO above
 	f.GoPdf.SetTextColor(r, g, b)
 }
 
@@ -251,7 +253,8 @@ func (f Impl) Line(x1 float64, y1 float64, x2 float64, y2 float64) {
 }
 
 func (f Impl) Write(w io.Writer) error {
-	return f.GoPdf.Write(w)
+	_, err := f.GoPdf.WriteTo(w)
+	return err
 }
 
 func (f Impl) GetMargins() (left, top, right, bottom float64) {
@@ -272,8 +275,7 @@ func (f Impl) AddFont(family string, styleStr string, data []byte) error {
 		style = style | gopdf.Underline
 	}
 
-	f.GoPdf.AddTTFFontDataWithOption(family, data, gopdf.TtfOption{
+	return f.GoPdf.AddTTFFontDataWithOption(family, data, gopdf.TtfOption{
 		Style: style,
 	})
-	return nil
 }

--- a/renderer.go
+++ b/renderer.go
@@ -133,7 +133,7 @@ func SetStyle(pdf PDF, s Style) {
 	textR, textG, textB, _ := s.TextColor.RGBA()
 	fillR, fillG, fillB, _ := s.FillColor.RGBA()
 
-	pdf.SetFont(s.Font.Family, s.format, int(s.Size))
+	_ = pdf.SetFont(s.Font.Family, s.format, int(s.Size))
 	pdf.SetTextColor(uint8(textR>>8), uint8(textG>>8), uint8(textB>>8))
 	pdf.SetFillColor(uint8(fillR>>8), uint8(fillG>>8), uint8(fillB>>8))
 	pdf.SetDrawColor(uint8(fillR>>8), uint8(fillG>>8), uint8(fillB>>8))

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -587,21 +587,21 @@ func (r *nodeRederFuncs) renderEmphasis(w *Writer, source []byte, node ast.Node,
 		switch n.Level {
 		case 2:
 			w.LogDebug("Strong (entering)", "")
-			w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "B", "", -1)
+			w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "B", "")
 			w.States.peek().textStyle.format += "B"
 		default:
 			w.LogDebug("Emph (entering)", "")
-			w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "I", "", -1)
+			w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "I", "")
 			w.States.peek().textStyle.format += "I"
 		}
 	} else {
 		switch n.Level {
 		case 2:
 			w.LogDebug("Strong (leaving)", "")
-			w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "B", "", -1)
+			w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "B", "")
 		default:
 			w.LogDebug("Emph (leaving)", "")
-			w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "I", "", -1)
+			w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "I", "")
 		}
 	}
 
@@ -614,7 +614,7 @@ func (r *nodeRederFuncs) renderStrikethrough(w *Writer, source []byte, node ast.
 		w.States.peek().textStyle.format += "S"
 	} else {
 		w.LogDebug("Strike (leaving)", "")
-		w.States.peek().textStyle.format = strings.Replace(w.States.peek().textStyle.format, "S", "", -1)
+		w.States.peek().textStyle.format = strings.ReplaceAll(w.States.peek().textStyle.format, "S", "")
 	}
 
 	return ast.WalkContinue, nil
@@ -743,7 +743,7 @@ func (r *nodeRederFuncs) renderTableCell(w *Writer, source []byte, node ast.Node
 		}
 		w.States.push(x)
 
-		w.WriteText(string(n.Text(source)))
+		w.WriteText(ExtractCellText(source, n))
 	} else {
 		w.States.pop()
 		w.LogDebug("TableCell (leaving)", "")

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -642,13 +642,39 @@ func (r *nodeRederFuncs) renderTaskCheckBox(w *Writer, source []byte, node ast.N
 	return ast.WalkContinue, nil
 }
 
+// ensureRowFitsOnPage adds a new page before rendering a table row if the
+// row's height would push past the page's bottom margin. Without this,
+// gofpdf's auto page break triggers per-cell: cell 0 fits on page N, cell 1
+// doesn't, gofpdf adds a page just for cell 1, then the SetY(startY) at the
+// end of the cell jumps us back to page N's Y while the active page is N+1.
+// Subsequent cells repeat the same pattern, producing one page per cell.
+// Pre-breaking the page ensures every cell in the row starts at the same Y
+// on the same page.
+func ensureRowFitsOnPage(w *Writer, rowHeight float64) {
+	_, pageHeight := w.Pdf.GetPageSize()
+	_, _, _, bottomMargin := w.Pdf.GetMargins()
+	if w.Pdf.GetY()+rowHeight > pageHeight-bottomMargin {
+		w.Pdf.AddPage()
+	}
+}
+
+// tableRowHeight returns the rendered height of the row at curTableRow.
+// Header rows are always one line tall; body rows multiply lineHeight by the
+// precomputed max-line count. Falls back to a single line if curTableRow is
+// past the precomputed list (malformed tables with stray rows).
+func tableRowHeight(lineHeight float64, isHeader bool) float64 {
+	if isHeader || curTableRow >= len(cellMaxLines) {
+		return lineHeight
+	}
+	return lineHeight * float64(cellMaxLines[curTableRow])
+}
+
 func (r *nodeRederFuncs) renderTable(w *Writer, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-		w.LogDebug("Table (entering)", "")
-
 		currentTableData = CollectTableData(w, source, node)
-		cellwidths = CalculateOptimalColumnWidths(w, currentTableData)
-		w.LogDebug("Table column widths calculated", fmt.Sprintf("Column widths: %v", cellwidths))
+		cellwidths, cellMaxLines = CalculateTableOptimalColumnWidthsRowHeights(w, currentTableData)
+
+		w.LogDebug("Table (entering)", fmt.Sprintf("Column widths: %v, Row line counts: %v", cellwidths, cellMaxLines))
 
 		x := &state{
 			containerType: east.KindTable,
@@ -671,7 +697,8 @@ func (r *nodeRederFuncs) renderTable(w *Writer, source []byte, node ast.Node, en
 		w.Pdf.BR(w.States.peek().textStyle.Size + w.States.peek().textStyle.Spacing)
 
 		currentTableData = nil
-		curdatacell = 0
+		curTableCol = 0
+		curTableRow = 0
 	}
 
 	return ast.WalkContinue, nil
@@ -685,8 +712,23 @@ func (r *nodeRederFuncs) renderTableHeader(w *Writer, source []byte, node ast.No
 			textStyle:     *w.Styles.THeader, listkind: notlist,
 			leftMargin: w.States.peek().leftMargin, isHeader: true,
 		}
+		// If the header row won't fit on the current page, break to a new
+		// page now so all of its cells render together. Otherwise gofpdf's
+		// auto page break would trigger mid-row, splitting cells across pages.
+		ensureRowFitsOnPage(w, x.textStyle.Size+x.textStyle.Spacing)
+		// Position the cursor at the table's left edge for the header cells.
+		// (goldmark puts TableCells directly under TableHeader rather than
+		// wrapping them in a TableRow, so the SetX in renderTableRow doesn't
+		// fire for the header row.)
+		w.Pdf.SetX(x.leftMargin)
+		curTableCol = 0
 		w.States.push(x)
 	} else {
+		// Advance Y past the header row before popping. The header isn't a
+		// TableRow in goldmark's AST, so renderTableRow's leave-time BR never
+		// fires for it; without this, the first body row would render on top
+		// of the header.
+		w.Pdf.BR(w.States.peek().textStyle.Size + w.States.peek().textStyle.Spacing)
 		w.States.pop()
 		w.LogDebug("TableHead (leaving)", "")
 	}
@@ -695,25 +737,51 @@ func (r *nodeRederFuncs) renderTableHeader(w *Writer, source []byte, node ast.No
 
 func (r *nodeRederFuncs) renderTableRow(w *Writer, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if entering {
-		w.LogDebug("TableRow (entering)", "")
+		// `isHeader` is inherited from the parent TableHeader/TableBody state
+		// so that header rows pick up the THeader style.
 		isHeader := w.States.peek().isHeader
+		rowLeftMargin := w.States.peek().leftMargin
 		x := &state{
 			containerType: east.KindTableRow,
 			textStyle:     *w.Styles.TBody, listkind: notlist,
-			leftMargin: w.States.peek().leftMargin, isHeader: isHeader,
+			leftMargin: rowLeftMargin, isHeader: isHeader,
 		}
-		if w.States.peek().isHeader {
+		if isHeader {
 			x.textStyle = *w.Styles.THeader
 		}
-		w.Pdf.BR(w.States.peek().textStyle.Size + w.States.peek().textStyle.Spacing)
+		rowHeight := tableRowHeight(x.textStyle.Size+x.textStyle.Spacing, isHeader)
+		w.LogDebug("TableRow (entering)", fmt.Sprintf("isHeader=%v Widths: %v Height: %v", isHeader, cellwidths, rowHeight))
 
-		// initialize cell widths slice; only one table at a time!
-		curdatacell = 0
+		// Break to a new page before rendering this row if it won't fit on
+		// the current one. See ensureRowFitsOnPage for why.
+		ensureRowFitsOnPage(w, rowHeight)
+
+		// Explicitly position X at the table's left edge for every row. The
+		// row-leave below calls BR(rowHeight) which already returns X to the
+		// page's left margin, but the table's left edge can differ from the
+		// page margin (e.g., when the table is inside a list or blockquote
+		// that pushed SetMarginLeft, or after some other element left the
+		// cursor offset). Doing it here makes the row-start invariant
+		// independent of prior cursor state.
+		w.Pdf.SetX(rowLeftMargin)
+		curTableCol = 0
 		w.States.push(x)
 	} else {
+		// All cells in the row have rendered with ln=0, so the cursor is at
+		// (rowEndX, rowStartY). Advance Y past the entire row before popping.
+		// Without this, the next row would start at startY + lineHeight and
+		// overlap multi-line content above it (original bug in issue #31).
+		s := w.States.peek()
+		w.Pdf.BR(tableRowHeight(s.textStyle.Size+s.textStyle.Spacing, s.isHeader))
+
 		w.States.pop()
 		w.LogDebug("TableRow (leaving)", "")
 		fill = !fill
+		// Only body rows have an entry in cellMaxLines, so only body rows
+		// advance the index.
+		if !s.isHeader {
+			curTableRow++
+		}
 	}
 
 	return ast.WalkContinue, nil
@@ -747,7 +815,7 @@ func (r *nodeRederFuncs) renderTableCell(w *Writer, source []byte, node ast.Node
 	} else {
 		w.States.pop()
 		w.LogDebug("TableCell (leaving)", "")
-		curdatacell++
+		curTableCol++
 	}
 
 	return ast.WalkSkipChildren, nil

--- a/table.go
+++ b/table.go
@@ -2,6 +2,8 @@ package pdf
 
 import (
 	"bytes"
+	"strings"
+
 	"github.com/yuin/goldmark/ast"
 	east "github.com/yuin/goldmark/extension/ast"
 )
@@ -82,37 +84,55 @@ func CollectTableData(w *Writer, source []byte, node ast.Node) *TableData {
 	return &tData
 }
 
-// CalculateOptimalColumnWidths based on content
-func CalculateOptimalColumnWidths(w *Writer, tableData *TableData) []float64 {
+// CalculateTableOptimalColumnWidthsRowHeights returns per-column widths and
+// per-body-row wrapped line counts sized to the table's content.
+//
+// Widths use a CSS-like min/max algorithm: each column gets its content's
+// natural width when the table fits in the available page width, otherwise
+// space is distributed proportionally between min (header/default) and max
+// (longest cell) widths.
+//
+// Line counts are computed by wrapping each body cell at its final column
+// width and taking the tallest cell in the row. Header rows always render
+// single-line so they aren't included here. The returned slice is indexed
+// by body-row position (matching curTableRow in the renderer).
+func CalculateTableOptimalColumnWidthsRowHeights(w *Writer, tableData *TableData) ([]float64, []int) {
 	if tableData == nil {
-		return []float64{}
+		return []float64{}, []int{}
 	}
 
-	// Determine number of columns from headers or first row
+	// Headers define column count when present; otherwise fall back to the
+	// first row. Subsequent rows with different cell counts are clamped to
+	// numCols below to avoid out-of-range indexing.
 	numCols := len(tableData.Headers)
 	if numCols == 0 && len(tableData.Rows) > 0 {
 		numCols = len(tableData.Rows[0])
 	}
 
 	if numCols == 0 {
-		return []float64{}
+		return []float64{}, []int{}
 	}
 	minWidths := make([]float64, numCols)
 	maxWidths := make([]float64, numCols)
 
-	// Get page dimensions
 	pageWidth, _ := w.Pdf.GetPageSize()
 	marginLeft, _, marginRight, _ := w.Pdf.GetMargins()
 	availableWidth := pageWidth - marginLeft - marginRight
 
-	// Calculate minimum widths based on headers
+	// Measure each cell with the font it will actually render with, so the
+	// line counts we predict here match what the renderer produces. If we
+	// skipped this, the PDF's active font would be whatever ran last before
+	// the table (e.g. a heading), and MeasureTextWidth/SplitText would give
+	// the wrong character-per-line ratio — leading to over-tall rows.
+	if w.Styles.THeader != nil {
+		SetStyle(w.Pdf, *w.Styles.THeader)
+	}
 	if len(tableData.Headers) > 0 {
 		for i, header := range tableData.Headers {
 			minWidths[i] = w.Pdf.MeasureTextWidth(header) + (2 * w.Pdf.MeasureTextWidth("m"))
 			maxWidths[i] = minWidths[i]
 		}
 	} else {
-		// No headers, use a default minimum width
 		defaultWidth := w.Pdf.MeasureTextWidth("mmmm")
 		for i := 0; i < numCols; i++ {
 			minWidths[i] = defaultWidth
@@ -120,11 +140,13 @@ func CalculateOptimalColumnWidths(w *Writer, tableData *TableData) []float64 {
 		}
 	}
 
-	// Calculate maximum widths based on content
+	if w.Styles.TBody != nil {
+		SetStyle(w.Pdf, *w.Styles.TBody)
+	}
 	for _, row := range tableData.Rows {
 		for i, cell := range row {
 			if i < numCols {
-				cellWidth := w.Pdf.MeasureTextWidth(cell) + (2 * w.Pdf.MeasureTextWidth("m"))
+				cellWidth := w.Pdf.MeasureTextWidth(strings.ReplaceAll(cell, "\n", " ")) + (2 * w.Pdf.MeasureTextWidth("m"))
 				if cellWidth > maxWidths[i] {
 					maxWidths[i] = cellWidth
 				}
@@ -142,7 +164,6 @@ func CalculateOptimalColumnWidths(w *Writer, tableData *TableData) []float64 {
 
 	// Determine final column widths
 	finalWidths := make([]float64, numCols)
-
 	if totalMax <= availableWidth {
 		// All columns can have their maximum width
 		copy(finalWidths, maxWidths)
@@ -163,5 +184,26 @@ func CalculateOptimalColumnWidths(w *Writer, tableData *TableData) []float64 {
 		}
 	}
 
-	return finalWidths
+	// Once widths are determined, count wrapped lines per row. Wrap at the
+	// same effective width the renderer will use (column minus 1m of padding)
+	// so the line count we predict here matches what gets drawn.
+	mWidth := w.Pdf.MeasureTextWidth("m")
+	finalMaxLines := make([]int, len(tableData.Rows))
+	for i, row := range tableData.Rows {
+		maxLines := 1
+		for colIndex, cell := range row {
+			if colIndex >= numCols {
+				break
+			}
+			splitWidth := finalWidths[colIndex] - mWidth
+			if splitWidth < 1 {
+				splitWidth = finalWidths[colIndex]
+			}
+			lines := w.Pdf.SplitText(strings.ReplaceAll(cell, "\n", " "), splitWidth)
+			maxLines = max(maxLines, len(lines))
+		}
+		finalMaxLines[i] = maxLines
+	}
+
+	return finalWidths, finalMaxLines
 }

--- a/table.go
+++ b/table.go
@@ -18,7 +18,7 @@ var currentTableData *TableData
 func ExtractCellText(source []byte, node ast.Node) string {
 	var buf bytes.Buffer
 
-	ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+	_ = ast.Walk(node, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
 		if !entering {
 			return ast.WalkContinue, nil
 		}

--- a/table_test.go
+++ b/table_test.go
@@ -102,7 +102,7 @@ func TestCalculateOptimalColumnWidths(t *testing.T) {
 				Pdf: mockPdf,
 			}
 
-			widths := CalculateOptimalColumnWidths(writer, tt.tableData)
+			widths, _ := CalculateTableOptimalColumnWidthsRowHeights(writer, tt.tableData)
 
 			if len(widths) != len(tt.expectedWidths) {
 				t.Errorf("Expected %d widths, got %d", len(tt.expectedWidths), len(widths))
@@ -140,7 +140,7 @@ func TestCalculateOptimalColumnWidths_EdgeCases(t *testing.T) {
 		},
 	}
 
-	widths := CalculateOptimalColumnWidths(writer, tableData)
+	widths, _ := CalculateTableOptimalColumnWidthsRowHeights(writer, tableData)
 
 	// Should handle gracefully and return 3 columns based on headers
 	if len(widths) != 3 {
@@ -153,7 +153,7 @@ func TestCalculateOptimalColumnWidths_EdgeCases(t *testing.T) {
 		Rows:    [][]string{},
 	}
 
-	widths2 := CalculateOptimalColumnWidths(writer, tableData2)
+	widths2, _ := CalculateTableOptimalColumnWidthsRowHeights(writer, tableData2)
 
 	// The third column should be wider than the second, which should be wider than the first
 	if widths2[0] >= widths2[1] || widths2[1] >= widths2[2] {

--- a/writer.go
+++ b/writer.go
@@ -56,7 +56,7 @@ func (w *Writer) WriteLink(s Style, display, url string) {
 	w.Pdf.WriteExternalLink(s.Size+s.Spacing, display, url)
 }
 
-// Write text based on the current state.
+// WriteText based on the current state.
 func (w *Writer) WriteText(stringContents string) {
 	bb := &bytes.Buffer{}
 	bufw := bufio.NewWriter(bb)
@@ -72,35 +72,69 @@ func (w *Writer) WriteText(stringContents string) {
 	} else if w.States.peek().containerType == ast.KindHeading {
 		escapeWriter{escapeHTML: w.EscapeHTML}.write(bufw, []byte(stringContents))
 	} else if w.States.peek().containerType == east.KindTableCell {
-		hw := cellwidths[curdatacell]
-		h := currentStyle.Size + currentStyle.Spacing
-		SetStyle(w.Pdf, currentStyle)
+		width := cellwidths[curTableCol]
+		lineHeight := currentStyle.Size + currentStyle.Spacing
 
 		if w.States.peek().isHeader {
-			// we assume single line based on column width calculation implementation
-			w.LogDebug("... table header cell", fmt.Sprintf("Width=%v, height=%v", hw, h))
-			w.Pdf.CellFormat(hw, h, stringContents, "1", 0, "L", true, 0, "")
+			w.LogDebug("... table header cell", fmt.Sprintf("Width=%v, height=%v", width, lineHeight))
+			w.Pdf.CellFormat(width, lineHeight, stringContents, "1", 0, "L", true, 0, "")
 		} else {
-			w.LogDebug("... table body cell", fmt.Sprintf("Width=%v, height=%v", hw, h))
-
-			// split into lines base on cell width
-			lines := w.Pdf.SplitText(stringContents, hw)
-			cellStartX := w.Pdf.GetX()
-			for i, line := range lines {
-				// new line before second or later lines
-				if i > 0 {
-					w.Pdf.BR(h)
-					w.Pdf.SetX(cellStartX)
-				}
-				w.Pdf.CellFormat(hw, h, line, "LR", 0, "", fill, 0, "")
+			// Body cell rendering, see issue #31.
+			//
+			// We can't pass the full row height to a single CellFormat call:
+			// gofpdf.CellFormat doesn't wrap, so overflowing text would draw on
+			// one line and visually escape the cell. Instead we split the text
+			// into wrapped lines ourselves and draw each on its own row of the
+			// cell. cellMaxLines (precomputed in table.go) gives the tallest
+			// cell in this row, so all cells in the row render the same number
+			// of "line slots" — short cells fill trailing slots with empty
+			// text but still draw the L/R border.
+			maxLines := 1
+			if curTableRow < len(cellMaxLines) {
+				maxLines = cellMaxLines[curTableRow]
 			}
+			w.LogDebug("... table body cell", fmt.Sprintf("Width=%v, lines=%v", width, maxLines))
+
+			// The column allocator (table.go) sized this column as text + 2*m
+			// of slack. Use half of that as wrap padding so the rendered text
+			// stops short of the right border without consuming all the slack —
+			// the remaining 1m keeps long words from being chopped mid-character
+			// when columns get squeezed by the available-width fit.
+			splitWidth := width - w.Pdf.MeasureTextWidth("m")
+			if splitWidth < 1 {
+				splitWidth = width
+			}
+			lines := w.Pdf.SplitText(stringContents, splitWidth)
+
+			// Each CellFormat below advances X by `width` but leaves Y alone
+			// (ln=0). We use BR+SetX to step down within this cell, then on
+			// exit restore Y to the row's top and bump X past the cell so the
+			// next sibling cell renders at the same baseline. Without this
+			// reset, taller cells would push neighbors down and break the row.
+			startX := w.Pdf.GetX()
+			startY := w.Pdf.GetY()
+			for i := 0; i < maxLines; i++ {
+				if i > 0 {
+					w.Pdf.BR(lineHeight)
+					w.Pdf.SetX(startX)
+				}
+				lineText := ""
+				if i < len(lines) {
+					lineText = lines[i]
+				}
+				w.Pdf.CellFormat(width, lineHeight, lineText, "LR", 0, "", fill, 0, "")
+			}
+			w.Pdf.SetY(startY)
+			w.Pdf.SetX(startX + width)
 		}
 	} else {
 		escapeWriter{escapeHTML: w.EscapeHTML}.write(bufw, []byte(stringContents))
 	}
 
-	_ = bufw.Flush()
-	w.Text(currentStyle, bb.String())
+	if bufw.Size() > 0 {
+		_ = bufw.Flush()
+		w.Text(currentStyle, bb.String())
+	}
 }
 
 // Converts a chroma.StyleEntry to a Style, based on the backtickStyle

--- a/writer.go
+++ b/writer.go
@@ -31,7 +31,7 @@ type Writer struct {
 func (r *Writer) LogDebug(source, msg string) {
 	if r.DebugWriter != nil {
 		indent := strings.Repeat("-", len(r.States.stack)-1)
-		r.DebugWriter.Write([]byte(fmt.Sprintf("%v[%v] %v\n", indent, source, msg)))
+		_, _ = fmt.Fprintf(r.DebugWriter, "%v[%v] %v\n", indent, source, msg)
 	}
 }
 
@@ -99,7 +99,7 @@ func (w *Writer) WriteText(stringContents string) {
 		escapeWriter{escapeHTML: w.EscapeHTML}.write(bufw, []byte(stringContents))
 	}
 
-	bufw.Flush()
+	_ = bufw.Flush()
 	w.Text(currentStyle, bb.String())
 }
 


### PR DESCRIPTION
## Description
Handle table rendering scenarios for multi line cells, including page break scenarios. The implementation is similar for column width in that it tries to determine the number of lines required for a cell based on the content and cell width.

**Example**

<img width="1006" height="916" alt="image" src="https://github.com/user-attachments/assets/ef49f0ba-bc3a-4816-8e19-73d375d8c3c0" />

_In this screenshot, the multi line cells make the entire row the same height (first page - top left). In the second page (top right) it correctly traverse a new page boundary on a tall row (bottom left). See #33 for before screenshot._


## Notes
- Assumes #33 is merged