### PR TITLE
Add basic gopdf support

### DIFF
--- a/compat.go
+++ b/compat.go
@@ -1,0 +1,21 @@
+package pdf
+
+import (
+	"context"
+
+	"github.com/go-swiss/fonts"
+
+	"github.com/stephenafamo/goldmark-pdf/fpdf"
+)
+
+type (
+	// Deprecated: Use fpdf.Impl
+	Fpdf = fpdf.Impl
+	// Deprecated: Use fpdf.Config
+	FpdfConfig = fpdf.Config
+)
+
+// Deprecated: Use fpdf.New
+func NewFpdf(ctx context.Context, c FpdfConfig, fontsCache fonts.Cache) *Fpdf {
+	return fpdf.New(ctx, c, fontsCache)
+}

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -19,32 +19,37 @@ import (
 	"github.com/yuin/goldmark/extension"
 
 	pdf "github.com/stephenafamo/goldmark-pdf"
-	gopdfBackend "github.com/stephenafamo/goldmark-pdf/gopdf"
+	"github.com/stephenafamo/goldmark-pdf/fpdf"
+	"github.com/stephenafamo/goldmark-pdf/gopdf"
 )
 
-// exampleConfig holds optional per-example hooks. Only the fpdf backend
-// supports HeaderFunc/FooterFunc in the current pre-merge gopdf code, so
-// gopdf renders without page chrome regardless of these fields. The zero
+// exampleConfig holds optional per-example hooks. Both backends now share
+// the same *Impl-pointer HeaderFunc/FooterFunc signature, so closures can
+// be written once per backend and dropped into either Config. The zero
 // value (returned by the map lookup for unknown keys) leaves every hook
 // nil.
 type exampleConfig struct {
-	fpdfHeader func(impl pdf.Fpdf, fc fonts.Cache) func()
-	fpdfFooter func(impl pdf.Fpdf, fc fonts.Cache) func()
+	fpdfHeader  func(impl *fpdf.Impl, fc fonts.Cache) func()
+	fpdfFooter  func(impl *fpdf.Impl, fc fonts.Cache) func()
+	gopdfHeader func(impl *gopdf.Impl, fc fonts.Cache) func()
+	gopdfFooter func(impl *gopdf.Impl, fc fonts.Cache) func()
 }
 
 // exampleConfigs keys on the .md basename. Add an entry to enable hooks
 // for a new example.
 var exampleConfigs = map[string]exampleConfig{
 	"header-footer": {
-		fpdfHeader: fpdfTitleBar,
-		fpdfFooter: fpdfPageNumber,
+		fpdfHeader:  fpdfTitleBar,
+		fpdfFooter:  fpdfPageNumber,
+		gopdfHeader: gopdfTitleBar,
+		gopdfFooter: gopdfPageNumber,
 	},
 }
 
 // fpdfTitleBar draws "Header / Footer Sample" in the top page margin.
 // Helvetica is gofpdf's built-in font so this works on page 1 without any
 // font-loading prep.
-func fpdfTitleBar(impl pdf.Fpdf, _ fonts.Cache) func() {
+func fpdfTitleBar(impl *fpdf.Impl, _ fonts.Cache) func() {
 	return func() {
 		_ = impl.SetFont("Helvetica", "B", 9)
 		ml, mt, mr, _ := impl.GetMargins()
@@ -56,7 +61,7 @@ func fpdfTitleBar(impl pdf.Fpdf, _ fonts.Cache) func() {
 }
 
 // fpdfPageNumber draws "Page N" centered in the bottom page margin.
-func fpdfPageNumber(impl pdf.Fpdf, _ fonts.Cache) func() {
+func fpdfPageNumber(impl *fpdf.Impl, _ fonts.Cache) func() {
 	return func() {
 		_ = impl.SetFont("Helvetica", "", 8)
 		ml, _, mr, mb := impl.GetMargins()
@@ -68,10 +73,32 @@ func fpdfPageNumber(impl pdf.Fpdf, _ fonts.Cache) func() {
 	}
 }
 
+func gopdfTitleBar(impl *gopdf.Impl, _ fonts.Cache) func() {
+	return func() {
+		_ = impl.SetFont("Roboto", "B", 9)
+		ml, mt, mr, _ := impl.GetMargins()
+		pw, _ := impl.GetPageSize()
+		impl.GoPdf.SetXY(ml, mt/2)
+		impl.SetTextColor(80, 80, 80)
+		impl.CellFormat(pw-ml-mr, 14, "Header / Footer Sample", "B", 0, "L", false, 0, "")
+	}
+}
+
+func gopdfPageNumber(impl *gopdf.Impl, _ fonts.Cache) func() {
+	return func() {
+		_ = impl.SetFont("Roboto", "", 8)
+		ml, _, mr, mb := impl.GetMargins()
+		pw, ph := impl.GetPageSize()
+		impl.GoPdf.SetXY(ml, ph-(mb/2)-10)
+		impl.SetTextColor(80, 80, 80)
+		impl.CellFormat(pw-ml-mr, 10, fmt.Sprintf("Page %d", impl.GoPdf.GetNumberOfPages()),
+			"T", 0, "C", false, 0, "")
+	}
+}
+
 // backends in render order. Each factory takes the title (the .md basename)
 // and the per-example config, and returns a pdf.Option that wires its
-// backend into the renderer. The gopdf factory ignores cfg because the
-// current InitConfig has no HeaderFunc/FooterFunc fields.
+// backend into the renderer.
 var backends = []struct {
 	name   string
 	option func(title string, cfg exampleConfig) pdf.Option
@@ -79,7 +106,7 @@ var backends = []struct {
 	{
 		name: "fpdf",
 		option: func(title string, cfg exampleConfig) pdf.Option {
-			return pdf.WithFpdf(context.Background(), pdf.FpdfConfig{
+			return pdf.WithFpdf(context.Background(), fpdf.Config{
 				Title:      title,
 				HeaderFunc: cfg.fpdfHeader,
 				FooterFunc: cfg.fpdfFooter,
@@ -88,10 +115,12 @@ var backends = []struct {
 	},
 	{
 		name: "gopdf",
-		option: func(title string, _ exampleConfig) pdf.Option {
-			return gopdfBackend.WithGoPdf(context.Background(), gopdfBackend.InitConfig{
-				Title: title,
-			})
+		option: func(title string, cfg exampleConfig) pdf.Option {
+			return pdf.WithPDF(gopdf.New(context.Background(), gopdf.Config{
+				Title:      title,
+				HeaderFunc: cfg.gopdfHeader,
+				FooterFunc: cfg.gopdfFooter,
+			}, nil))
 		},
 	},
 }

--- a/fpdf/fpdf.go
+++ b/fpdf/fpdf.go
@@ -1,4 +1,4 @@
-package pdf
+package fpdf
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 )
 
 // gofpdf panics on runes above the BMP (its Cw array is 65536 entries), so
-// substitute non-BMP runes with U+FFFD. Proper fix is the signintech/gopdf
+// substitute non-BMP runes with U+FFFD. Proper fix is the gopdf
 // backend (gopdf/), which handles them natively but is incomplete.
 // See https://github.com/stephenafamo/goldmark-pdf/issues/27.
 const (
@@ -36,25 +36,8 @@ func sanitizeUnicode(s string) string {
 	return s
 }
 
-type FpdfConfig struct {
-	Title   string
-	Subject string
-
-	Orientation string // Default Portrait
-	PaperSize   string // Default A4
-
-	Logo       io.Reader
-	LogoFormat string
-
-	// Header
-	HeaderFunc func(impl Fpdf, fontsCache fonts.Cache) func()
-
-	// Footer
-	FooterFunc func(impl Fpdf, fontsCache fonts.Cache) func()
-}
-
-func NewFpdf(ctx context.Context, c FpdfConfig, fontsCache fonts.Cache) *Fpdf {
-	fpdf := Fpdf{
+func New(ctx context.Context, c Config, fontsCache fonts.Cache) *Impl {
+	fpdf := Impl{
 		Fpdf:    gofpdf.New(c.Orientation, "pt", c.PaperSize, ""),
 		anchors: make(map[string]int),
 	}
@@ -63,12 +46,19 @@ func NewFpdf(ctx context.Context, c FpdfConfig, fontsCache fonts.Cache) *Fpdf {
 	fpdf.Fpdf.SetSubject(c.Subject, true)
 	fpdf.Fpdf.SetCellMargin(0)
 
+	// Pre-register the logo so HeaderFunc/FooterFunc closures can pull it
+	// up with impl.UseImage("logo", ...) without having to call
+	// RegisterImage themselves. Mirrors the gopdf backend's behavior.
+	if c.Logo != nil {
+		fpdf.RegisterImage("logo", c.LogoFormat, c.Logo)
+	}
+
 	if c.HeaderFunc != nil {
-		fpdf.Fpdf.SetHeaderFunc(c.HeaderFunc(fpdf, fontsCache))
+		fpdf.Fpdf.SetHeaderFunc(c.HeaderFunc(&fpdf, fontsCache))
 	}
 
 	if c.FooterFunc != nil {
-		fpdf.Fpdf.SetFooterFunc(c.FooterFunc(fpdf, fontsCache))
+		fpdf.Fpdf.SetFooterFunc(c.FooterFunc(&fpdf, fontsCache))
 	}
 
 	fpdf.AddPage()
@@ -83,74 +73,82 @@ type internalLink struct {
 	anchor        string
 }
 
-type Fpdf struct {
+type Impl struct {
 	Fpdf        *gofpdf.Fpdf
 	anchorLinks []internalLink
 	anchors     map[string]int
 }
 
 // Add a new page
-func (f Fpdf) AddPage() {
+func (f Impl) AddPage() {
 	f.Fpdf.AddPage()
 }
 
 // Position
-func (f Fpdf) GetX() float64 {
+func (f Impl) GetX() float64 {
 	return f.Fpdf.GetX()
 }
 
-func (f Fpdf) GetY() float64 {
+func (f Impl) GetY() float64 {
 	return f.Fpdf.GetY()
 }
 
-func (f Fpdf) SetX(x float64) {
+func (f Impl) SetX(x float64) {
 	f.Fpdf.SetX(x)
 }
 
-func (f Fpdf) SetY(y float64) {
+func (f Impl) SetY(y float64) {
 	f.Fpdf.SetY(y)
 }
 
 // Page size
-func (f Fpdf) GetPageSize() (width float64, height float64) {
+func (f Impl) GetPageSize() (width float64, height float64) {
 	return f.Fpdf.GetPageSize()
 }
 
 // Margins
-func (f Fpdf) SetMarginLeft(margin float64) {
+func (f Impl) SetMarginLeft(margin float64) {
 	f.Fpdf.SetLeftMargin(margin)
 }
 
-func (f Fpdf) SetMarginRight(margin float64) {
+func (f Impl) SetMarginRight(margin float64) {
 	f.Fpdf.SetRightMargin(margin)
 }
 
-func (f Fpdf) SetMarginTop(margin float64) {
+func (f Impl) SetMarginTop(margin float64) {
 	f.Fpdf.SetTopMargin(margin)
 }
 
-func (f Fpdf) SetFont(family string, style string, size int) error {
+// SetMarginBottom sets the bottom page margin via gofpdf's auto-page-break
+// trigger — that's the only way gofpdf exposes the bottom margin, since
+// gofpdf.SetMargins only accepts left/top/right. Always re-enables auto
+// page break so the renderer's page-break expectations hold.
+func (f Impl) SetMarginBottom(margin float64) {
+	f.Fpdf.SetAutoPageBreak(true, margin)
+}
+
+func (f Impl) SetFont(family string, style string, size int) error {
 	f.Fpdf.SetFont(family, style, float64(size))
 	return nil
 }
 
 // Writing
-func (f Fpdf) WriteText(height float64, text string) {
+func (f Impl) WriteText(height float64, text string) {
 	f.Fpdf.Write(height, sanitizeUnicode(text))
 }
 
-func (f Fpdf) CellFormat(w float64, h float64, txtStr string, borderStr string, ln int, alignStr string, fill bool, link int, linkStr string) {
+func (f Impl) CellFormat(w float64, h float64, txtStr string, borderStr string, ln int, alignStr string, fill bool, link int, linkStr string) {
 	f.Fpdf.SetCellMargin(0)
 	f.Fpdf.CellFormat(w, h, sanitizeUnicode(txtStr), borderStr, ln, alignStr, fill, link, linkStr)
 }
 
-func (f *Fpdf) AddInternalLink(anchor string) {
+func (f *Impl) AddInternalLink(anchor string) {
 	linkID := f.Fpdf.AddLink()
 	f.Fpdf.SetLink(linkID, f.GetY(), -1)
 	f.anchors[anchor] = linkID
 }
 
-func (f *Fpdf) WriteInternalLink(lineHeight float64, text string, anchor string) {
+func (f *Impl) WriteInternalLink(lineHeight float64, text string, anchor string) {
 	text = sanitizeUnicode(text)
 	f.anchorLinks = append(f.anchorLinks, internalLink{
 		page:   f.Fpdf.PageNo(),
@@ -163,29 +161,29 @@ func (f *Fpdf) WriteInternalLink(lineHeight float64, text string, anchor string)
 	f.Fpdf.WriteLinkString(lineHeight, text, "#"+anchor)
 }
 
-func (f Fpdf) WriteExternalLink(lineHeight float64, text string, destination string) {
+func (f Impl) WriteExternalLink(lineHeight float64, text string, destination string) {
 	f.Fpdf.WriteLinkString(lineHeight, sanitizeUnicode(text), destination)
 }
 
-func (f Fpdf) BR(height float64) {
+func (f Impl) BR(height float64) {
 	f.Fpdf.Ln(height)
 }
 
 // Images
-func (f Fpdf) RegisterImage(id string, format string, src io.Reader) {
+func (f Impl) RegisterImage(id string, format string, src io.Reader) {
 	f.Fpdf.RegisterImageOptionsReader(id, gofpdf.ImageOptions{ImageType: format, ReadDpi: false}, src)
 }
 
-func (f Fpdf) UseImage(imgID string, x, y, w, h float64) {
+func (f Impl) UseImage(imgID string, x, y, w, h float64) {
 	f.Fpdf.ImageOptions(imgID, x, y, w, h, true, gofpdf.ImageOptions{ImageType: "", ReadDpi: false}, 0, "")
 }
 
 // Measuring
-func (f Fpdf) MeasureTextWidth(text string) float64 {
+func (f Impl) MeasureTextWidth(text string) float64 {
 	return f.Fpdf.GetStringWidth(sanitizeUnicode(text))
 }
 
-func (f Fpdf) SplitText(txt string, w float64) []string {
+func (f Impl) SplitText(txt string, w float64) []string {
 	lines := f.Fpdf.SplitLines([]byte(sanitizeUnicode(txt)), w)
 
 	split := make([]string, len(lines))
@@ -197,32 +195,32 @@ func (f Fpdf) SplitText(txt string, w float64) []string {
 }
 
 // Colors
-func (f Fpdf) SetDrawColor(r uint8, g uint8, b uint8) {
+func (f Impl) SetDrawColor(r uint8, g uint8, b uint8) {
 	f.Fpdf.SetDrawColor(int(r), int(g), int(b))
 }
 
-func (f Fpdf) SetFillColor(r uint8, g uint8, b uint8) {
+func (f Impl) SetFillColor(r uint8, g uint8, b uint8) {
 	f.Fpdf.SetFillColor(int(r), int(g), int(b))
 }
 
-func (f Fpdf) SetTextColor(r uint8, g uint8, b uint8) {
+func (f Impl) SetTextColor(r uint8, g uint8, b uint8) {
 	f.Fpdf.SetTextColor(int(r), int(g), int(b))
 }
 
 // Width
-func (f Fpdf) SetLineWidth(width float64) {
+func (f Impl) SetLineWidth(width float64) {
 	f.Fpdf.SetLineWidth(width)
 }
 
-func (f Fpdf) Line(x1 float64, y1 float64, x2 float64, y2 float64) {
+func (f Impl) Line(x1 float64, y1 float64, x2 float64, y2 float64) {
 	f.Fpdf.Line(x1, y1, x2, y2)
 }
 
-func (f Fpdf) Circle(x, y, r float64) {
+func (f Impl) Circle(x, y, r float64) {
 	f.Fpdf.Circle(x, y, r, "F")
 }
 
-func (f Fpdf) Write(w io.Writer) error {
+func (f Impl) Write(w io.Writer) error {
 	// write the internal links
 	for _, link := range f.anchorLinks {
 		id, ok := f.anchors[link.anchor]
@@ -238,11 +236,11 @@ func (f Fpdf) Write(w io.Writer) error {
 	return f.Fpdf.Output(w)
 }
 
-func (f Fpdf) GetMargins() (left, top, right, bottom float64) {
+func (f Impl) GetMargins() (left, top, right, bottom float64) {
 	return f.Fpdf.GetMargins()
 }
 
-func (f Fpdf) AddFont(family string, style string, data []byte) error {
+func (f Impl) AddFont(family string, style string, data []byte) error {
 	f.Fpdf.AddUTF8FontFromBytes(family, style, data)
 	return nil
 }

--- a/fpdf/option.go
+++ b/fpdf/option.go
@@ -1,0 +1,26 @@
+package fpdf
+
+import (
+	"io"
+
+	"github.com/go-swiss/fonts"
+)
+
+type Config struct {
+	Title   string
+	Subject string
+
+	Orientation string // Default Portrait
+	PaperSize   string // Default A4
+
+	Logo       io.Reader
+	LogoFormat string
+
+	// HeaderFunc and FooterFunc receive *Impl so that header/footer closures
+	// running on backends with mirrored graphics state (notably the gopdf
+	// backend) can mutate it through the wrapper. fpdf has nothing to track
+	// today, but the signature is unified across backends to keep the same
+	// closure literal portable between WithFpdf and WithGoPdf.
+	HeaderFunc func(impl *Impl, fontsCache fonts.Cache) func()
+	FooterFunc func(impl *Impl, fontsCache fonts.Cache) func()
+}

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/go-swiss/fonts v0.0.0-20230807175105-90067c2f5042
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/phpdave11/gofpdf v1.4.3
-	github.com/signintech/gopdf v0.33.0
-	github.com/yuin/goldmark v1.7.13
+	github.com/signintech/gopdf v0.36.0
+	github.com/yuin/goldmark v1.8.2
 	google.golang.org/api v0.243.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -57,11 +57,15 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/signintech/gopdf v0.33.0 h1:VanhSnrO03H9roKp4y4ckVmTmezxk8OzSJL/Sx1WlNg=
 github.com/signintech/gopdf v0.33.0/go.mod h1:d23eO35GpEliSrF22eJ4bsM3wVeQJTjXTHq5x5qGKjA=
+github.com/signintech/gopdf v0.36.0 h1:/7gPwoLtlNv5tPNpYuo3T3z0mWgo62pTrCvVNAiOo2Q=
+github.com/signintech/gopdf v0.36.0/go.mod h1:d23eO35GpEliSrF22eJ4bsM3wVeQJTjXTHq5x5qGKjA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
 github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
+github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6hwnZ41NSFTO5q4LYDtJRXBf2PD0rNBkeB/lus=

--- a/gopdf/gopdf.go
+++ b/gopdf/gopdf.go
@@ -1,38 +1,246 @@
 package gopdf
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
 	"io"
-	"math"
 	"strings"
 
+	"github.com/go-swiss/fonts"
 	"github.com/signintech/gopdf"
+	"github.com/signintech/gopdf/fontmaker/core"
+	pdf "github.com/stephenafamo/goldmark-pdf"
 )
 
+var (
+	// Compile-time check that *Impl satisfies the pdf.PDF interface
+	_ pdf.PDF = (*Impl)(nil)
+)
+
+// registeredImage caches the parsed holder and natural dimensions so UseImage
+// can honor h=0 (auto-scale to aspect ratio) without re-decoding.
+type registeredImage struct {
+	holder        gopdf.ImageHolder
+	naturalWidth  float64
+	naturalHeight float64
+}
+
+// paperSizeFromConfig resolves the configured page size. PaperSizeRect wins
+// when non-nil (escape hatch for arbitrary dimensions); otherwise the named
+// PaperSize string is mapped to a gopdf preset. Empty or
+// unrecognized strings fall back to A4 — matches fpdf.Config's "Default A4"
+// behavior so the two backends behave identically on zero-config use.
+func paperSizeFromConfig(c Config) gopdf.Rect {
+	switch strings.ToUpper(c.PaperSize) {
+	case "A3":
+		return *gopdf.PageSizeA3
+	case "A5":
+		return *gopdf.PageSizeA5
+	case "LETTER":
+		return *gopdf.PageSizeLetter
+	case "LEGAL":
+		return *gopdf.PageSizeLegal
+	case "TABLOID":
+		return *gopdf.PageSizeTabloid
+	default:
+		return *gopdf.PageSizeA4
+	}
+}
+
+func New(ctx context.Context, c Config, fontsCache fonts.Cache) *Impl {
+	// gopdf has no orientation flag — pages are sized purely by W/H. Copy
+	// the Rect (so unexported fields ride along) and swap dimensions for
+	// landscape.
+	paperRect := paperSizeFromConfig(c)
+	// Match gofpdf: "l"/"landscape" (case-insensitive) selects landscape;
+	// everything else is portrait.
+	switch strings.ToLower(c.Orientation) {
+	case "l", "landscape":
+		paperRect.W, paperRect.H = paperRect.H, paperRect.W
+	}
+
+	gpdf := &Impl{
+		GoPdf:  &gopdf.GoPdf{},
+		Width:  paperRect.W,
+		Height: paperRect.H,
+		images: make(map[string]registeredImage),
+	}
+
+	gpdf.GoPdf.Start(gopdf.Config{
+		Unit:     gopdf.UnitPT,
+		PageSize: paperRect,
+	})
+
+	// Apply default margins via the public interface methods so the
+	// wrapper's defaults flow through the same code path callers use when
+	// overriding margins post-construction. Matches gofpdf's effective
+	// defaults (1cm L/T/R + 2cm bottom auto-page-break trigger).
+	gpdf.SetMarginLeft(defaultMarginLTR)
+	gpdf.SetMarginTop(defaultMarginLTR)
+	gpdf.SetMarginRight(defaultMarginLTR)
+	gpdf.SetMarginBottom(defaultMarginBottom)
+
+	gpdf.GoPdf.SetInfo(gopdf.PdfInfo{
+		Title:   c.Title,
+		Subject: c.Subject,
+	})
+
+	// Pre-register the logo so HeaderFunc/FooterFunc closures can pull it up
+	// with impl.UseImage("logo", ...). Registering before AddPage means it's
+	// available the first time the header runs (gopdf fires headerFunc from
+	// inside AddPage).
+	if c.Logo != nil {
+		gpdf.RegisterImage("logo", c.LogoFormat, c.Logo)
+	}
+
+	// Wire header/footer before AddPage so they fire on page 1. gopdf invokes
+	// both at page-open, matching gofpdf's — footer closures still need to absolutely
+	// position themselves via SetY(-margin) if they want to sit at the bottom of the page.
+	if c.HeaderFunc != nil {
+		gpdf.GoPdf.AddHeader(c.HeaderFunc(gpdf, fontsCache))
+	}
+
+	if c.FooterFunc != nil {
+		gpdf.GoPdf.AddFooter(c.FooterFunc(gpdf, fontsCache))
+	}
+
+	// Preload the default text font before page 1. gopdf has no
+	// built-in core fonts, so without this, HeaderFunc/FooterFunc closures
+	// firing on page 1's AddPage have nothing to SetFont — the renderer's
+	// own addStyleFonts pass runs later, after Convert() starts. Loading
+	// here mirrors fpdf's "Helvetica always available" UX. Failures
+	// (network down + cold cache) are swallowed: page 1's hooks no-op,
+	// page 2+ still pick up the font once the renderer loads its set.
+	_ = pdf.AddFonts(ctx, gpdf, []pdf.Font{pdf.FontRoboto}, fontsCache)
+
+	gpdf.AddPage()
+
+	return gpdf
+}
+
+// Impl wraps gopdf and mirrors graphics-state values that gopdf
+// doesn't keep on `gp.curr` and that don't auto-replay into new pages'
+// content streams. AddPage re-issues these on every page; text-drawing ops
+// re-issue fill color on the way out because gopdf emits a non-stroking-color
+// (`rg`) inside BT/ET to set the text color, and `rg` is the *global* fill
+// color in PDF — it leaks past ET and would otherwise turn the next fill
+// rect black. This mirrors PDF's native q/Q idiom; the wrapper models it
+// because gopdf doesn't expose raw q/Q emission.
+//
+// Font and text color are also mirrored — not because gopdf forgets them
+// across pages (it doesn't), but because HeaderFunc/FooterFunc closures
+// run *inside* AddPage and routinely override both. Without restoration,
+// a page break that fires mid-paragraph leaves the renderer's next chunk
+// rendered in the header's font (which is what bug screenshot #2 showed).
+//
+// Setters that mutate mirrored fields take pointer receivers so field writes
+// survive past the call; the interface stores `*Impl`.
 type Impl struct {
 	Width  float64
 	Height float64
 	GoPdf  *gopdf.GoPdf
 
-	// TODO: remove these unused color fields once it's confirmed nothing relies on them.
-	textR, textG, textB       uint8 //nolint:unused
+	images map[string]registeredImage
+
 	fillR, fillG, fillB       uint8
-	strokeR, strokeG, strokeB uint8 //nolint:unused
+	strokeR, strokeG, strokeB uint8
+	lineWidth                 float64
+	lineWidthSet              bool // distinguish "never set" (don't restore) from "set to 0"
+
+	fontFamily string
+	fontStyle  string
+	fontSize   int
+	fontSet    bool
+
+	textR, textG, textB uint8
+	textColorSet        bool
+
+	// Per-font TypoAscender/UnitsPerEm ratio, captured at AddFont time. Used
+	// by the text-draw path to mimic gofpdf's font-agnostic baseline placement
+	// (baseline = cellTop + 0.5·h + 0.3·Size) on top of gopdf, which
+	// otherwise reads each font's OS/2 metrics and lands the baseline at
+	// cellTop + typoAscender·Size. See drawCellBaselineAligned for the shift.
+	fontAscenderRatio map[fontKey]float64
+
+	// addedFonts records family+style combos already registered via AddFont,
+	// so callers (notably the renderer's addStyleFonts pass running after
+	// gopdf.New's own preload) don't double-register.
+	addedFonts map[fontKey]struct{}
+
+	// errs buffers non-fatal failures from text/image/measure paths so the
+	// caller sees them via Write() instead of getting a panic mid-render.
+	// Matches gofpdf's swallow-at-draw-time, surface-at-output-time
+	// semantics — keeps a flaky font or undecodable image from killing the
+	// whole pipeline.
+	errs []error
 }
 
+// recordErr buffers a non-fatal rendering error. Write() returns errors.Join
+// of the accumulated errs so the caller can inspect what was dropped.
+func (f *Impl) recordErr(err error) {
+	if err == nil {
+		return
+	}
+	f.errs = append(f.errs, err)
+}
+
+type fontKey struct {
+	family string
+	style  string
+}
+
+// maybeAddPage matches gofpdf's auto-page-break trigger: add a new page if
+// drawing the next element of height `lineHeight` would extend past the
+// bottom margin.
+//
+// Bails out when the cursor is already past the printable bottom — that's
+// the signature of a caller drawing in the bottom margin on purpose
+// (typically a FooterFunc closure positioning itself with SetXY). Without
+// this guard, the footer's draw would trigger AddPage, which fires the
+// footer closure again, which triggers another AddPage — infinite recursion
+// until the goroutine stack blows.
 func (f Impl) maybeAddPage(lineHeight float64) {
 	Y := f.GoPdf.GetY()
 	H := f.Height
-	TopM := f.GoPdf.MarginTop()
 	BottomM := f.GoPdf.MarginBottom()
 
-	if math.Mod(Y, H) > H-TopM-BottomM-lineHeight {
-		f.GoPdf.AddPage()
+	if Y > H-BottomM {
+		return
+	}
+
+	if Y+lineHeight > H-BottomM {
+		f.AddPage()
 	}
 }
 
-// Add a new page
+// AddPage delegates to gopdf and re-issues every piece of wrapper-tracked
+// graphics state onto the new page. PDF graphics state doesn't span pages
+// (each content stream starts at the PDF defaults: black fill, black stroke,
+// 1pt line width), and gopdf doesn't auto-replay these. Re-issuing also
+// allocates the page's content stream — gopdf attaches /Contents lazily,
+// and a page with no draw ops serializes with a malformed /Contents entry.
 func (f Impl) AddPage() {
 	f.GoPdf.AddPage()
+	f.GoPdf.SetFillColor(f.fillR, f.fillG, f.fillB)
+	f.GoPdf.SetStrokeColor(f.strokeR, f.strokeG, f.strokeB)
+	if f.lineWidthSet {
+		f.GoPdf.SetLineWidth(f.lineWidth)
+	}
+	// Font and text color restoration runs after fill/stroke so the page
+	// looks visually identical to what the caller had before a HeaderFunc
+	// or FooterFunc closure (fired by GoPdf.AddPage above) touched things.
+	if f.fontSet {
+		_ = f.GoPdf.SetFont(f.fontFamily, f.fontStyle, f.fontSize)
+	}
+	if f.textColorSet {
+		f.GoPdf.SetTextColor(f.textR, f.textG, f.textB)
+	}
 }
 
 // Position
@@ -70,26 +278,157 @@ func (f Impl) SetMarginTop(margin float64) {
 	f.GoPdf.SetTopMargin(margin)
 }
 
-func (f Impl) SetFont(family string, style string, size int) error {
+// SetMarginBottom updates the bottom margin via the four-arg SetMargins call,
+// preserving the current left/top/right margins. Drives the maybeAddPage
+// auto-page-break trigger that fires when a draw op would cross
+// `pageHeight - marginBottom`.
+func (f Impl) SetMarginBottom(margin float64) {
+	l, t, r, _ := f.GoPdf.Margins()
+	f.GoPdf.SetMargins(l, t, r, margin)
+}
+
+func (f *Impl) SetFont(family string, style string, size int) error {
+	f.fontFamily, f.fontStyle, f.fontSize, f.fontSet = family, style, size, true
 	return f.GoPdf.SetFont(family, style, size)
 }
 
-// Writing
-func (f Impl) WriteText(h float64, text string) {
-	f.maybeAddPage(h)
-	w, _ := f.GoPdf.MeasureTextWidth(text)
-	err := f.GoPdf.CellWithOption(&gopdf.Rect{W: w, H: h}, text, gopdf.CellOption{
-		Align: gopdf.Left,
-		Float: gopdf.Right,
-	})
-	if err != nil {
-		panic(err)
+// baselineShift returns the Y offset to apply before Top-aligned Cell draw so
+// that the glyph baseline lands at the same font-agnostic position gofpdf uses:
+//
+//	baseline_y = cellTop + 0.5·h + 0.3·Size
+//
+// Why match gofpdf's formula: it puts the baseline at a fixed offset from the
+// cell top regardless of font, so every font is visually centered in its line
+// box AND runs across fonts (Roboto body next to Roboto Mono inline code)
+// align without per-font compensation. gopdf's native behavior
+// reads each font's OS/2 sTypoAscender and lands the baseline at
+// cellTop + typoAscender·Size — that's font-specific, so it misaligns
+// cross-font runs AND mis-centers within the line box when the font's
+// metrics are tuned for tight web line-heights. Modern Google Roboto's
+// sTypoAscender = 1536/2048 ≈ 0.75 (vs the older ~0.93) is the case that
+// motivated this.
+//
+// Math: gopdf Top alignment puts baseline at curr.y + typoAscender·Size.
+// We want baseline at cellTop + 0.5·h + 0.3·Size. So shift curr.y down by
+// (0.5·h + 0.3·Size − typoAscender·Size) before the draw and restore after.
+//
+// If we couldn't parse the font (typoAscender unknown), shift is 0 — the
+// result falls back to gofpdf native behavior for that font.
+func (f Impl) baselineShift(h float64) float64 {
+	if !f.fontSet {
+		return 0
+	}
+	// Strip "U" before lookup: underline is a rendering flag, not a font
+	// variant, so we register Roboto under "" / "B" / "I" / "BI" only.
+	// gopdf's SetFont matches the same way (style&^Underline).
+	style := strings.ReplaceAll(strings.ToUpper(f.fontStyle), "U", "")
+	thisAsc, ok := f.fontAscenderRatio[fontKey{family: f.fontFamily, style: style}]
+	if !ok {
+		return 0
+	}
+	size := float64(f.fontSize)
+	return 0.5*h + 0.3*size - thisAsc*size
+}
+
+// WriteText writes flowing text from the current cursor, breaking to the
+// next line on each `\n` and wrapping each piece at word boundaries via
+// WriteTextLine. Matches gofpdf.Write semantics.
+//
+// Pointer receiver so downstream draws can call recordErr through the
+// same Impl when CellWithOption fails.
+func (f *Impl) WriteText(h float64, text string) {
+	if text == "" {
+		return
+	}
+	leftMargin, _, _, _ := f.GoPdf.Margins()
+	for i, segment := range strings.Split(text, "\n") {
+		if i > 0 {
+			f.GoPdf.Br(h)
+			f.GoPdf.SetX(leftMargin)
+		}
+		f.WriteTextLine(h, segment)
 	}
 }
 
-func (f Impl) CellFormat(w float64, h float64, txtStr string, borderStr string, ln int, alignStr string, fill bool, link int, linkStr string) {
+// WriteTextLine lays out a single logical line of text (no internal newlines)
+// from the current cursor, wrapping at word boundaries when the next chunk
+// would cross the right margin and continuing on subsequent visual lines from
+// the left margin. A chunk wider than a full line falls back to a character
+// break so progress is always made.
+func (f *Impl) WriteTextLine(h float64, text string) {
+	if strings.ContainsRune(text, '\n') {
+		// Robustness: fall back to WriteText (which handles newlines) instead
+		// of panicking on an internal contract violation.
+		f.WriteText(h, text)
+		return
+	}
+
+	if text == "" {
+		return
+	}
+
+	pageWidth, _ := f.GetPageSize()
+	leftMargin, _, rightMargin, _ := f.GoPdf.Margins()
+	rightX := pageWidth - rightMargin
+
+	draw := func(s string) {
+		if s == "" {
+			return
+		}
+		f.maybeAddPage(h)
+		w, _ := f.GoPdf.MeasureTextWidth(s)
+		f.drawCellBaselineAligned(w, h, s)
+	}
+
+	wrap := func() {
+		f.GoPdf.Br(h)
+		f.GoPdf.SetX(leftMargin)
+	}
+
+	// Chunks are alternating non-space / space runs so whitespace can be
+	// dropped at wrap points (matching gofpdf, which doesn't carry leading
+	// spaces onto new lines).
+	for _, chunk := range splitWords(text) {
+		availW := rightX - f.GoPdf.GetX()
+		chunkW, _ := f.GoPdf.MeasureTextWidth(chunk)
+
+		if chunkW <= availW {
+			draw(chunk)
+			continue
+		}
+
+		// Pure-whitespace chunk that doesn't fit: just wrap.
+		if strings.TrimSpace(chunk) == "" {
+			wrap()
+			continue
+		}
+
+		// Word doesn't fit. Wrap first if anything's already on this line.
+		if f.GoPdf.GetX() > leftMargin {
+			wrap()
+			availW = rightX - leftMargin
+		}
+
+		// Word still wider than a full line — break at character boundary
+		// to make forward progress.
+		if chunkW > availW {
+			head, tail := breakAtWidth(f.GoPdf, chunk, availW)
+			draw(head)
+			for tail != "" {
+				wrap()
+				availW = rightX - leftMargin
+				head, tail = breakAtWidth(f.GoPdf, tail, availW)
+				draw(head)
+			}
+			continue
+		}
+
+		draw(chunk)
+	}
+}
+
+func (f *Impl) CellFormat(w float64, h float64, txtStr string, borderStr string, ln int, alignStr string, fill bool, link int, linkStr string) {
 	f.maybeAddPage(h)
-	f.GoPdf.SetFillColor(f.fillR, f.fillG, f.fillB)
 	borderStr = strings.ToUpper(borderStr)
 
 	var border int
@@ -115,52 +454,102 @@ func (f Impl) CellFormat(w float64, h float64, txtStr string, borderStr string, 
 		float = gopdf.Bottom
 	}
 
-	x := f.GoPdf.GetX()
-	y := f.GoPdf.GetY()
-	f.GoPdf.RectFromUpperLeftWithStyle(x, y, w, h, "F")
+	// Paint the background only when requested. The fill color is whatever
+	// the renderer's SetStyle most recently set; the post-text fill pop in
+	// the CellWithOption block below keeps it from leaking to black.
+	if fill {
+		x := f.GoPdf.GetX()
+		y := f.GoPdf.GetY()
+		f.GoPdf.RectFromUpperLeftWithStyle(x, y, w, h, "F")
+	}
+
+	// alignStr: horizontal (L/C/R, default L) + vertical (T/M/B, default M),
+	// matching gofpdf's "LM"-as-default. Vertical-middle keeps table-cell
+	// text visually consistent with the fpdf backend.
+	upper := strings.ToUpper(alignStr)
+	align := 0
+	switch {
+	case strings.Contains(upper, "C"):
+		align |= gopdf.Center
+	case strings.Contains(upper, "R"):
+		align |= gopdf.Right
+	default:
+		align |= gopdf.Left
+	}
+	switch {
+	case strings.Contains(upper, "T"):
+		// Top is gopdf's default when no vertical flag is set.
+	case strings.Contains(upper, "B"):
+		align |= gopdf.Bottom
+	default:
+		align |= gopdf.Middle
+	}
 
 	err := f.GoPdf.CellWithOption(&gopdf.Rect{W: w, H: h}, txtStr, gopdf.CellOption{
-		Align:  gopdf.Left,
+		Align:  align,
 		Border: border,
 		Float:  float,
 	})
 	if err != nil {
-		panic(err)
+		f.recordErr(fmt.Errorf("gopdf: CellFormat draw: %w", err))
 	}
+	// Pop the fill color the text op clobbered. Always run — gopdf may have
+	// emitted partial PDF commands before the error, so the next op still
+	// needs the correct fill state.
+	f.GoPdf.SetFillColor(f.fillR, f.fillG, f.fillB)
 }
 
 func (f Impl) AddInternalLink(anchor string) {
 	f.GoPdf.SetAnchor(anchor)
 }
 
-func (f Impl) WriteInternalLink(h float64, text string, anchor string) {
+func (f *Impl) WriteInternalLink(h float64, text string, anchor string) {
 	f.maybeAddPage(h)
 	x := f.GoPdf.GetX()
 	y := f.GoPdf.GetY()
 	w, _ := f.GoPdf.MeasureTextWidth(text)
-	err := f.GoPdf.CellWithOption(&gopdf.Rect{W: w, H: h}, text, gopdf.CellOption{
-		Align: gopdf.Left,
-		Float: gopdf.Right,
-	})
-	if err != nil {
-		panic(err)
-	}
-	f.GoPdf.AddExternalLink(anchor, x, y, w, h)
+	f.drawCellBaselineAligned(w, h, text)
+	// AddInternalLink uses the unshifted cell bounds: the link's clickable
+	// region tracks the visual cell rect (which is anchored at the unshifted
+	// y), even though the glyphs inside it shifted to align baselines.
+	f.GoPdf.AddInternalLink(anchor, x, y, w, h)
 }
 
-func (f Impl) WriteExternalLink(h float64, text string, destination string) {
+func (f *Impl) WriteExternalLink(h float64, text string, destination string) {
 	f.maybeAddPage(h)
 	x := f.GoPdf.GetX()
 	y := f.GoPdf.GetY()
 	w, _ := f.GoPdf.MeasureTextWidth(text)
+	f.drawCellBaselineAligned(w, h, text)
+	f.GoPdf.AddExternalLink(destination, x, y, w, h)
+}
+
+// drawCellBaselineAligned draws a Cell at the current cursor with the
+// font-agnostic gofpdf baseline placement applied via Y pre-shift (see
+// baselineShift). Centralizes the save-y / shift / draw / restore-y
+// dance so every text-draw path (WriteTextLine, WriteInternalLink,
+// WriteExternalLink) shares it.
+func (f *Impl) drawCellBaselineAligned(w, h float64, text string) {
+	yShift := f.baselineShift(h)
+	savedY := f.GoPdf.GetY()
+	if yShift != 0 {
+		f.GoPdf.SetY(savedY + yShift)
+	}
+
 	err := f.GoPdf.CellWithOption(&gopdf.Rect{W: w, H: h}, text, gopdf.CellOption{
 		Align: gopdf.Left,
 		Float: gopdf.Right,
 	})
-	if err != nil {
-		panic(err)
+
+	if yShift != 0 {
+		f.GoPdf.SetY(savedY)
 	}
-	f.GoPdf.AddExternalLink(destination, x, y, w, h)
+
+	if err != nil {
+		f.recordErr(fmt.Errorf("gopdf: cell draw: %w", err))
+	}
+	// Pop the fill color the text op clobbered. Always run — see CellFormat.
+	f.GoPdf.SetFillColor(f.fillR, f.fillG, f.fillB)
 }
 
 func (f Impl) BR(height float64) {
@@ -169,82 +558,137 @@ func (f Impl) BR(height float64) {
 }
 
 // Images
-func (f Impl) RegisterImage(id string, format string, src io.Reader) {
-	// f.GoPdf.RegisterImageOptionsReader(id, gofpdf.ImageOptions{ImageType: format}, src)
+func (f *Impl) RegisterImage(id string, format string, src io.Reader) {
+	if f.images == nil {
+		return
+	}
+	if _, ok := f.images[id]; ok {
+		return
+	}
+
+	data, err := io.ReadAll(src)
+	if err != nil {
+		f.recordErr(fmt.Errorf("gopdf: read image %q: %w", id, err))
+		return
+	}
+
+	holder, err := gopdf.ImageHolderByBytes(data)
+	if err != nil {
+		f.recordErr(fmt.Errorf("gopdf: decode image %q: %w", id, err))
+		return
+	}
+
+	// Natural dimensions let UseImage honor the renderer's h=0 (auto-height)
+	// contract. DecodeConfig only reads headers, so it's cheap.
+	var naturalW, naturalH float64
+	if cfg, _, err := image.DecodeConfig(bytes.NewReader(data)); err == nil {
+		naturalW = float64(cfg.Width)
+		naturalH = float64(cfg.Height)
+	}
+
+	f.images[id] = registeredImage{
+		holder:        holder,
+		naturalWidth:  naturalW,
+		naturalHeight: naturalH,
+	}
 }
 
-func (f Impl) UseImage(imgID string, x, y, w, h float64) {
-	// f.checkNewPage()
-	// f.GoPdf.ImageOptions(imgID, x, y, w, h, false, gofpdf.ImageOptions{ImageType: "", ReadDpi: true}, 0, "")
+func (f *Impl) UseImage(imgID string, x, y, w, h float64) {
+	img, ok := f.images[imgID]
+	if !ok {
+		return
+	}
+
+	// The renderer passes h=0 to mean "auto-scale to aspect ratio".
+	if h == 0 && img.naturalWidth > 0 && img.naturalHeight > 0 {
+		h = w * img.naturalHeight / img.naturalWidth
+	}
+
+	f.maybeAddPage(h)
+
+	rect := &gopdf.Rect{W: w, H: h}
+	if err := f.GoPdf.ImageByHolderWithOptions(img.holder, gopdf.ImageOptions{
+		X:    x,
+		Y:    f.GoPdf.GetY(),
+		Rect: rect,
+	}); err != nil {
+		f.recordErr(fmt.Errorf("gopdf: draw image %q: %w", imgID, err))
+		return
+	}
+
+	// gopdf leaves Y put; advance it so subsequent content flows below the image.
+	f.GoPdf.SetY(f.GoPdf.GetY() + h)
 }
 
 // Measuring
-func (f Impl) MeasureTextWidth(text string) float64 {
+func (f *Impl) MeasureTextWidth(text string) float64 {
 	width, err := f.GoPdf.MeasureTextWidth(text)
 	if err != nil {
-		panic(err)
+		f.recordErr(fmt.Errorf("gopdf: measure text width: %w", err))
+		return 0
 	}
 	return width
 }
 
-func (f Impl) SplitText(text string, width float64) []string {
-	gp := f.GoPdf
-	var lineText []rune
-	var lineTexts []string
-	utf8Texts := []rune(text)
-	utf8TextsLen := len(utf8Texts) // utf8 string quantity
-	if utf8TextsLen == 0 {
-		return lineTexts
+func (f *Impl) SplitText(text string, width float64) []string {
+	if text == "" {
+		return nil
 	}
-	for i := 0; i < utf8TextsLen; i++ {
-		lineWidth, err := gp.MeasureTextWidth(string(lineText))
-		if err != nil {
-			panic(err)
-		}
-		runeWidth, err := gp.MeasureTextWidth(string(utf8Texts[i]))
-		if err != nil {
-			panic(err)
-		}
-		if lineWidth+runeWidth > width && utf8Texts[i] != '\n' {
-			lineTexts = append(lineTexts, string(lineText))
-			lineText = lineText[0:0]
-			continue
-		}
-		if utf8Texts[i] == '\n' {
-			lineTexts = append(lineTexts, string(lineText))
-			lineText = lineText[0:0]
-			continue
-		}
-		if i == utf8TextsLen-1 {
-			lineText = append(lineText, utf8Texts[i])
-			lineTexts = append(lineTexts, string(lineText))
-		}
-		lineText = append(lineText, utf8Texts[i])
 
+	gp := f.GoPdf
+	var lines []string
+	var line []rune
+
+	for _, r := range text {
+		if r == '\n' {
+			lines = append(lines, string(line))
+			line = line[:0]
+			continue
+		}
+
+		// Measure with the candidate rune included so the wrap point is the
+		// rune that pushed us over — not the one after it.
+		candidate := append(line, r) //nolint:gocritic // line is reassigned below; aliasing is intentional
+		cw, err := gp.MeasureTextWidth(string(candidate))
+		if err != nil {
+			f.recordErr(fmt.Errorf("gopdf: measure for split: %w", err))
+			// Best-effort fallback: include the rune without a width check so
+			// we still make forward progress instead of dropping the tail.
+			line = candidate
+			continue
+		}
+		if cw > width && len(line) > 0 {
+			lines = append(lines, string(line))
+			line = []rune{r}
+			continue
+		}
+		line = candidate
 	}
-	return lineTexts
+	if len(line) > 0 {
+		lines = append(lines, string(line))
+	}
+	return lines
 }
 
 // Colors
-// TODO: value receivers make these field assignments ineffective; switch to pointer
-// receivers (or drop the fields) once the dependent code paths are verified.
-func (f Impl) SetDrawColor(r uint8, g uint8, b uint8) {
-	f.strokeR, f.strokeB, f.strokeG = r, g, b //nolint:staticcheck // SA4005: see TODO above
+func (f *Impl) SetDrawColor(r uint8, g uint8, b uint8) {
+	f.strokeR, f.strokeG, f.strokeB = r, g, b
 	f.GoPdf.SetStrokeColor(r, g, b)
 }
 
-func (f Impl) SetFillColor(r uint8, g uint8, b uint8) {
-	f.fillR, f.fillB, f.fillG = r, g, b //nolint:staticcheck // SA4005: see TODO above
+func (f *Impl) SetFillColor(r uint8, g uint8, b uint8) {
+	f.fillR, f.fillG, f.fillB = r, g, b
 	f.GoPdf.SetFillColor(r, g, b)
 }
 
-func (f Impl) SetTextColor(r uint8, g uint8, b uint8) {
-	f.textR, f.textB, f.textG = r, g, b //nolint:staticcheck // SA4005: see TODO above
+func (f *Impl) SetTextColor(r uint8, g uint8, b uint8) {
+	f.textR, f.textG, f.textB, f.textColorSet = r, g, b, true
 	f.GoPdf.SetTextColor(r, g, b)
 }
 
 // Width
-func (f Impl) SetLineWidth(width float64) {
+func (f *Impl) SetLineWidth(width float64) {
+	f.lineWidth, f.lineWidthSet = width, true
 	f.GoPdf.SetLineWidth(width)
 }
 
@@ -259,17 +703,29 @@ func (f Impl) Circle(x, y, r float64) {
 	f.GoPdf.Oval(x-r/2, y-r/2, x+r/2, y+r/2)
 }
 
-func (f Impl) Write(w io.Writer) error {
-	_, err := f.GoPdf.WriteTo(w)
-	return err
+func (f *Impl) Write(w io.Writer) error {
+	if _, err := f.GoPdf.WriteTo(w); err != nil {
+		return err
+	}
+	// Surface any non-fatal errors collected during rendering. errors.Join
+	// returns nil for an empty slice, so the happy path stays clean.
+	return errors.Join(f.errs...)
 }
 
 func (f Impl) GetMargins() (left, top, right, bottom float64) {
 	return f.GoPdf.Margins()
 }
 
-func (f Impl) AddFont(family string, styleStr string, data []byte) error {
+func (f *Impl) AddFont(family string, styleStr string, data []byte) error {
 	styleStr = strings.ToUpper(styleStr)
+	key := fontKey{family: family, style: styleStr}
+
+	// Skip work if this family+style was already registered — ascender ratio
+	// is already cached and gopdf would otherwise leak duplicate
+	// font objects into the output PDF (see addedFonts comment on Impl).
+	if _, ok := f.addedFonts[key]; ok {
+		return nil
+	}
 
 	style := gopdf.Regular
 	if strings.Contains(styleStr, "B") {
@@ -282,7 +738,31 @@ func (f Impl) AddFont(family string, styleStr string, data []byte) error {
 		style = style | gopdf.Underline
 	}
 
-	return f.GoPdf.AddTTFFontDataWithOption(family, data, gopdf.TtfOption{
+	// Capture this font's TypoAscender/UnitsPerEm ratio so the text-draw path
+	// can apply gofpdf-style baseline placement (see baselineShift).
+	// Parser errors are non-fatal: fall through and let gopdf
+	// surface them on AddTTFFontDataWithOption; the draw path then falls
+	// back to native baseline for that font.
+	parser := &core.TTFParser{}
+	if err := parser.ParseByReader(bytes.NewReader(data)); err == nil {
+		upem := parser.UnitsPerEm()
+		if upem > 0 {
+			if f.fontAscenderRatio == nil {
+				f.fontAscenderRatio = make(map[fontKey]float64)
+			}
+			f.fontAscenderRatio[key] = float64(parser.TypoAscender()) / float64(upem)
+		}
+	}
+
+	if err := f.GoPdf.AddTTFFontDataWithOption(family, data, gopdf.TtfOption{
 		Style: style,
-	})
+	}); err != nil {
+		return err
+	}
+
+	if f.addedFonts == nil {
+		f.addedFonts = make(map[fontKey]struct{})
+	}
+	f.addedFonts[key] = struct{}{}
+	return nil
 }

--- a/gopdf/gopdf_test.go
+++ b/gopdf/gopdf_test.go
@@ -1,0 +1,398 @@
+package gopdf
+
+import (
+	"bytes"
+	"compress/zlib"
+	"context"
+	"encoding/base64"
+	"image/color"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+
+	pdf "github.com/stephenafamo/goldmark-pdf"
+)
+
+// findTTF looks up a TTF font from a couple of well-known system locations.
+// Tests that need a real font skip when none is found so the suite stays
+// hermetic on machines without system fonts.
+func findTTF(t *testing.T) []byte {
+	t.Helper()
+	candidates := []string{
+		"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+		"/usr/share/fonts/dejavu/DejaVuSans.ttf",
+		"/Library/Fonts/Arial.ttf",
+		"/System/Library/Fonts/Supplemental/Arial.ttf",
+	}
+	for _, p := range candidates {
+		if data, err := os.ReadFile(p); err == nil {
+			return data
+		}
+	}
+	t.Skipf("no system TTF font found in known locations: %v", candidates)
+	return nil
+}
+
+// newTestPDF returns a gopdf backend pre-loaded with a DejaVu font under all
+// four styles, plus the option that wires it into the renderer (lets
+// addStyleFonts skip downloading anything).
+func newTestPDF(t *testing.T) (pdf.Option, *Impl) {
+	t.Helper()
+	ttf := findTTF(t)
+
+	opt := WithGoPdf(context.Background(), Config{Title: "test"})
+
+	// WithGoPdf returns an OptionFunc that sets Config.PDF. Pull the underlying
+	// *Impl back out via a throwaway Config so the test can poke its state.
+	cfg := &pdf.Config{}
+	opt.SetConfig(cfg)
+	impl, ok := cfg.PDF.(*Impl)
+	if !ok {
+		t.Fatalf("expected *gopdf.Impl, got %T", cfg.PDF)
+	}
+
+	for _, style := range []string{pdf.FontStyleRegular, pdf.FontStyleBold, pdf.FontStyleItalic, pdf.FontStyleBoldItalic} {
+		if err := impl.AddFont("DejaVu", style, ttf); err != nil {
+			t.Fatalf("AddFont(%q): %v", style, err)
+		}
+	}
+
+	return opt, impl
+}
+
+// newTestMD builds a goldmark renderer wired to a DejaVu-fonted gopdf backend.
+// Pass extensions via `exts`; renderer-level tweaks (link color, etc.) via opts.
+func newTestMD(t *testing.T, exts []goldmark.Extender, opts ...pdf.Option) goldmark.Markdown {
+	t.Helper()
+	pdfOpt, _ := newTestPDF(t)
+	dejavu := pdf.Font{
+		CanUseForText: true,
+		CanUseForCode: true,
+		Family:        "DejaVu",
+		Type:          pdf.FontTypeCustom,
+	}
+	rendererOpts := append([]pdf.Option{
+		pdfOpt,
+		pdf.WithHeadingFont(dejavu),
+		pdf.WithBodyFont(dejavu),
+		pdf.WithCodeFont(dejavu),
+	}, opts...)
+	return goldmark.New(
+		goldmark.WithExtensions(exts...),
+		goldmark.WithRenderer(pdf.New(rendererOpts...)),
+	)
+}
+
+// 1x1 transparent PNG used by image-related tests.
+const onePxPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+
+func TestRegisterImage_AutoHeightFromAspectRatio(t *testing.T) {
+	img := Impl{
+		GoPdf:  nil, // not exercised on this path
+		images: make(map[string]registeredImage),
+	}
+
+	data, err := base64.StdEncoding.DecodeString(onePxPNG)
+	if err != nil {
+		t.Fatalf("decode test PNG: %v", err)
+	}
+	img.RegisterImage("test", "png", bytes.NewReader(data))
+
+	got, ok := img.images["test"]
+	if !ok {
+		t.Fatal("expected image to be registered")
+	}
+	if got.naturalWidth != 1 || got.naturalHeight != 1 {
+		t.Errorf("expected 1x1 natural dimensions, got %vx%v", got.naturalWidth, got.naturalHeight)
+	}
+}
+
+func TestRegisterImage_DuplicateIDKeepsFirst(t *testing.T) {
+	img := Impl{images: make(map[string]registeredImage)}
+	data, _ := base64.StdEncoding.DecodeString(onePxPNG)
+
+	img.RegisterImage("dup", "png", bytes.NewReader(data))
+	first := img.images["dup"].holder
+
+	// Second call with the same id should be ignored, not overwrite.
+	img.RegisterImage("dup", "png", bytes.NewReader(data))
+	second := img.images["dup"].holder
+
+	if first != second {
+		t.Error("duplicate RegisterImage should not replace existing holder")
+	}
+}
+
+// Full end-to-end render through goldmark + the gopdf backend. Catches
+// regressions in the wrapper interface: font loading, text writing, links,
+// tables, code blocks, images, page output. We don't validate visual output
+// — just that the pipeline produces a syntactically-valid PDF for a mix of
+// elements the renderer exercises.
+func TestEndToEndRender(t *testing.T) {
+	md := newTestMD(t,
+		[]goldmark.Extender{extension.Table, extension.Strikethrough},
+		pdf.WithLinkColor(color.RGBA{0, 0, 200, 255}),
+	)
+
+	source := `# Heading One
+
+A paragraph with **bold**, *italic*, and ~~strikethrough~~ text plus an
+[external link](https://example.com) and an [internal link](#heading-one).
+
+## Lists
+
+- item one
+- item two
+- item three
+
+` + "```go\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n```" + `
+
+## Table
+
+| Col A | Col B |
+|-------|-------|
+| 1     | 2     |
+| 3     | 4     |
+`
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(source), &buf); err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+
+	out := buf.Bytes()
+	if len(out) == 0 {
+		t.Fatal("expected non-empty PDF output")
+	}
+	if !bytes.HasPrefix(out, []byte("%PDF-")) {
+		t.Errorf("expected PDF magic header, got %q", firstBytes(out, 16))
+	}
+	if !bytes.Contains(out, []byte("%%EOF")) {
+		t.Error("expected PDF trailer marker missing")
+	}
+}
+
+// Verifies the wrapper handles `h=0` (auto-scale) when used inline through
+// the renderer's UseImage path.
+func TestEndToEndRender_WithImage(t *testing.T) {
+	md := newTestMD(t, nil)
+
+	source := "# img\n\n![pixel](data:image/png;base64," + onePxPNG + ")\n\nafter\n"
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(source), &buf); err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+	if !bytes.HasPrefix(buf.Bytes(), []byte("%PDF-")) {
+		t.Errorf("expected PDF output, got first 16 bytes: %q", firstBytes(buf.Bytes(), 16))
+	}
+}
+
+// Long paragraphs (a single ast.Text node with no inline markup) must wrap at
+// the right margin instead of running off the page.
+func TestWriteText_WrapsLongParagraph(t *testing.T) {
+	md := newTestMD(t, nil)
+
+	source := []byte(strings.Repeat("This is a long paragraph that needs to wrap. ", 20))
+	var buf bytes.Buffer
+	if err := md.Convert(source, &buf); err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+
+	// The whole text is preserved in the PDF stream after wrapping; if the
+	// renderer dropped a wrap-point rune the assertion below would fail.
+	// We can't decode the PDF's text content easily, so we look at the raw
+	// bytes for individual short snippets that occur many times.
+	out := buf.Bytes()
+	if !bytes.HasPrefix(out, []byte("%PDF-")) {
+		t.Fatal("not a PDF")
+	}
+	// Output should be larger than a non-wrapped one-page PDF: roughly,
+	// long text means more content stream bytes (rough sanity check).
+	if len(out) < 5000 {
+		t.Errorf("output suspiciously small (%d bytes) — text may not have flowed", len(out))
+	}
+}
+
+// Orientation matches gofpdf: "L"/"Landscape" (case-insensitive) swaps the
+// page dimensions, everything else stays portrait.
+func TestOrientation(t *testing.T) {
+	cases := []struct {
+		name        string
+		orientation string
+		wantWide    bool // true if final page width > height
+	}{
+		{"empty defaults portrait", "", false},
+		{"P portrait", "P", false},
+		{"Portrait", "Portrait", false},
+		{"l landscape", "l", true},
+		{"L", "L", true},
+		{"Landscape mixed case", "LandScape", true},
+		{"unknown falls back to portrait", "diagonal", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opt := WithGoPdf(context.Background(), Config{
+				Orientation: tc.orientation,
+			})
+			cfg := &pdf.Config{}
+			opt.SetConfig(cfg)
+			impl := cfg.PDF.(*Impl)
+			w, h := impl.GetPageSize()
+			if (w > h) != tc.wantWide {
+				t.Errorf("orientation %q: got %v×%v (wide=%v), wantWide=%v",
+					tc.orientation, w, h, w > h, tc.wantWide)
+			}
+		})
+	}
+}
+
+// Every filled rectangle in the PDF stream must be preceded by its own `rg`
+// (nonstroking color) command, so the fill never inherits the text color
+// that gopdf emits inside BT/ET.
+func TestCellFormat_FillRectAlwaysHasOwnFillColor(t *testing.T) {
+	md := newTestMD(t, []goldmark.Extender{extension.Table})
+
+	// A table with rows of mixed wrapped-line counts forces multi-line cells
+	// to issue multiple fill rects per row — the exact case where the
+	// nonstroking-color leak from BT/ET text used to bleed black into the
+	// fill state.
+	source := []byte(`| A | B | C |
+|---|---|---|
+| ` + strings.Repeat("x ", 40) + ` | one | ` + strings.Repeat("y ", 40) + ` |
+| short | short | short |
+`)
+	var buf bytes.Buffer
+	if err := md.Convert(source, &buf); err != nil {
+		t.Fatalf("Convert: %v", err)
+	}
+
+	streams := extractContentStreams(t, buf.Bytes())
+	if len(streams) == 0 {
+		t.Fatal("no content streams found")
+	}
+
+	for _, s := range streams {
+		if !bytes.Contains(s, []byte(" re f")) {
+			continue
+		}
+		// For each "re f" instance, the most recent nonstroking color before
+		// it (within the same stream) must come from a wrapper-emitted `rg`
+		// — not from inside a BT/ET text block. A simple sufficient check:
+		// every `re f` must be immediately preceded (within ~3 lines) by an
+		// `rg` command outside any BT/ET block.
+		lines := strings.Split(string(s), "\n")
+		inText := false
+		lastRgIdx := -1
+		for i, l := range lines {
+			switch {
+			case l == "BT":
+				inText = true
+			case l == "ET":
+				inText = false
+			case !inText && strings.HasSuffix(strings.TrimSpace(l), " rg"):
+				lastRgIdx = i
+			case strings.HasSuffix(strings.TrimSpace(l), " re f"):
+				// must have seen an `rg` outside BT/ET within 5 lines
+				if lastRgIdx == -1 || i-lastRgIdx > 5 {
+					t.Errorf("fill rect at line %d has no recent non-text `rg` (lastRgIdx=%d)", i, lastRgIdx)
+				}
+			}
+		}
+	}
+}
+
+// extractContentStreams pulls inflated content streams out of a PDF. gopdf
+// emits FlateDecode-compressed streams; we look for "stream...endstream"
+// regions and try to inflate each.
+func extractContentStreams(t *testing.T, pdfBytes []byte) [][]byte {
+	t.Helper()
+	re := regexp.MustCompile(`(?s)stream\r?\n(.+?)\r?\nendstream`)
+	var out [][]byte
+	for _, m := range re.FindAllSubmatch(pdfBytes, -1) {
+		r, err := zlib.NewReader(bytes.NewReader(m[1]))
+		if err != nil {
+			continue
+		}
+		data, _ := io.ReadAll(r)
+		r.Close()
+		if bytes.Contains(data, []byte(" re ")) {
+			out = append(out, data)
+		}
+	}
+	return out
+}
+
+func TestSplitText_DoesNotDropOverflowRune(t *testing.T) {
+	impl := newFontedImpl(t)
+
+	in := strings.Repeat("a", 200)
+	wTotal := impl.MeasureTextWidth(in)
+
+	// Splitting at half-width should produce at least two lines, and the joined
+	// result must reproduce the input exactly.
+	lines := impl.SplitText(in, wTotal/2)
+	if len(lines) < 2 {
+		t.Fatalf("expected >= 2 lines for half-width split, got %d", len(lines))
+	}
+	if joined := strings.Join(lines, ""); joined != in {
+		t.Errorf("rune(s) dropped during wrap.\n  in:  %q\n  out: %q", in, joined)
+	}
+}
+
+func firstBytes(b []byte, n int) string {
+	if len(b) < n {
+		n = len(b)
+	}
+	return string(b[:n])
+}
+
+// When the cursor is already in the bottom margin (a FooterFunc drawing
+// absolute-positioned), maybeAddPage must not auto-page-break. Breaking
+// here would fire the footer again and recurse until stack overflow.
+func TestMaybeAddPage_SkipsWhenCursorInBottomMargin(t *testing.T) {
+	opt := WithGoPdf(context.Background(), Config{})
+	cfg := &pdf.Config{}
+	opt.SetConfig(cfg)
+	impl := cfg.PDF.(*Impl)
+
+	// Position cursor halfway into the bottom margin — typical FooterFunc Y.
+	_, ph := impl.GetPageSize()
+	_, _, _, mb := impl.GetMargins()
+	impl.SetY(ph - mb/2)
+
+	before := impl.GoPdf.GetNumberOfPages()
+	impl.maybeAddPage(10)
+	after := impl.GoPdf.GetNumberOfPages()
+
+	if after != before {
+		t.Errorf("maybeAddPage added a page (%d→%d) when cursor was past bottom margin", before, after)
+	}
+}
+
+// Confirms the guard didn't disable the legitimate auto-page-break: cursor
+// in the content area where the next op crosses the bottom margin.
+func TestMaybeAddPage_BreaksWhenContentOverflows(t *testing.T) {
+	opt := WithGoPdf(context.Background(), Config{})
+	cfg := &pdf.Config{}
+	opt.SetConfig(cfg)
+	impl := cfg.PDF.(*Impl)
+
+	// One point above the printable bottom; a 10pt line would cross it.
+	_, ph := impl.GetPageSize()
+	_, _, _, mb := impl.GetMargins()
+	impl.SetY(ph - mb - 1)
+
+	before := impl.GoPdf.GetNumberOfPages()
+	impl.maybeAddPage(10)
+	after := impl.GoPdf.GetNumberOfPages()
+
+	if after != before+1 {
+		t.Errorf("maybeAddPage did not break: pages %d→%d", before, after)
+	}
+}

--- a/gopdf/option.go
+++ b/gopdf/option.go
@@ -2,91 +2,56 @@ package gopdf
 
 import (
 	"context"
+	"io"
 
-	"github.com/signintech/gopdf"
+	"github.com/go-swiss/fonts"
 	pdf "github.com/stephenafamo/goldmark-pdf"
 )
 
-type InitConfig struct {
+// gofpdf-equivalent default margins, in points: 1cm on L/T/R and 2cm on the
+// bottom (gofpdf's auto-page-break trigger sits at 2*margin). Matching these
+// keeps the gopdf and fpdf backends visually aligned.
+const (
+	defaultMarginLTR    = 28.35
+	defaultMarginBottom = 56.70
+)
+
+type Config struct {
 	Title   string
 	Subject string
 
-	PaperSize *gopdf.Rect // Default A4
+	// Orientation accepts "P"/"Portrait" or "L"/"Landscape" (case-insensitive).
+	// Empty and unknown values default to portrait.
+	Orientation string
+
+	// PaperSize selects a named page size: "A3", "A4", "A5", "Letter",
+	// "Legal", "Tabloid" (case-insensitive). Empty defaults to "A4". This
+	// mirrors fpdf.Config.PaperSize
+	PaperSize string
+
+	// Logo, when set, is auto-registered under the image ID "logo" before the
+	// first page is added. HeaderFunc/FooterFunc closures can then draw it
+	// with impl.UseImage("logo", ...) without having to call RegisterImage
+	// themselves. LogoFormat is passed straight through to RegisterImage.
+	Logo       io.Reader
+	LogoFormat string
+
+	// HeaderFunc and FooterFunc are invoked by gopdf on every
+	// AddPage (the underlying lib fires both at page-open). The returned
+	// closure is what actually draws; the outer function exists so callers
+	// can capture the wrapper impl and fonts cache they need at draw time.
+	//
+	// Mirrors the fpdf backend's HeaderFunc/FooterFunc shape, but receives
+	// *Impl (not a value copy) because gopdf's wrapper tracks mirrored
+	// graphics state through pointer receivers — passing a value would
+	// silently drop those mutations.
+	HeaderFunc func(impl *Impl, fontsCache fonts.Cache) func()
+	FooterFunc func(impl *Impl, fontsCache fonts.Cache) func()
 }
 
-func WithGoPdf(ctx context.Context, c InitConfig) pdf.Option {
-	if c.PaperSize == nil {
-		c.PaperSize = gopdf.PageSizeA4
-	}
-
-	gpdf := Impl{
-		GoPdf:  &gopdf.GoPdf{},
-		Width:  c.PaperSize.W,
-		Height: c.PaperSize.H,
-	}
-
-	gpdf.GoPdf.Start(gopdf.Config{
-		Unit:     gopdf.UnitPT,
-		PageSize: *c.PaperSize,
-	})
-
-	gpdf.GoPdf.SetInfo(gopdf.PdfInfo{
-		Title:   c.Title,
-		Subject: c.Subject,
-	})
-
-	// if c.HeaderStyle == (pdf.Style{}) {
-	// c.HeaderStyle = pdf.Style{Font: pdf.FontRoboto, Size: 12, Spacing: 10,
-	// TextColor: color.RGBA{10, 10, 10, 0}, FillColor: color.RGBA{255, 255, 255, 0}}
-	// }
-
-	// if c.FooterStyle == (pdf.Style{}) {
-	// c.FooterStyle = pdf.Style{Font: pdf.FontRoboto, Size: 11, Spacing: 2,
-	// TextColor: color.RGBA{10, 10, 10, 0}, FillColor: color.RGBA{255, 255, 255, 0}}
-	// }
-
-	// pdf.AddFonts(ctx, gpdf, []pdf.Font{c.HeaderStyle.Font, c.FooterStyle.Font})
-
-	// if c.Logo != nil {
-	// gpdf.RegisterImage("logo", c.LogoFormat, c.Logo)
-	// }
-
-	// mleft, mtop, mright, mbottom := gpdf.GetMargins()
-	// pageWidth, _ := gpdf.GetPageSize()
-
-	// LH := c.HeaderStyle.Size + c.HeaderStyle.Spacing
-
-	// if c.HeaderText != "" {
-	// gpdf.GoPdf.SetHeaderFunc(func() {
-	// pdf.SetStyle(gpdf, c.HeaderStyle)
-
-	// gpdf.SetX(mleft + 5)
-
-	// if c.Logo != nil {
-	// var logoWidth float64 = c.HeaderStyle.Size
-	// gpdf.SetX(gpdf.GetX() + logoWidth)
-	// gpdf.UseImage("logo", mleft, mtop, logoWidth, logoWidth)
-	// }
-
-	// gpdf.CellFormat(0, 0, c.HeaderText, "", 0, "LT", false, 0, "")
-	// gpdf.WriteText(LH, "\n")
-	// })
-	// }
-
-	// if c.FooterText != "" {
-	// gpdf.GoPdf.SetFooterFunc(func() {
-	// pdf.SetStyle(gpdf, c.FooterStyle)
-	// gpdf.SetY(-mbottom)
-	// gpdf.GoPdf.Ln(-1)
-	// gpdf.GoPdf.Ln(-1)
-	// gpdf.SetX(mleft)
-	// gpdf.CellFormat(0, 0, fmt.Sprintf("Page %d", gpdf.GoPdf.PageNo()), "", 0, "LB", false, 0, "")
-	// gpdf.SetX(mleft)
-	// gpdf.CellFormat(pageWidth-mleft-mright, 0, c.FooterText, "", 0, "RB", false, 0, "")
-	// })
-	// }
-
-	gpdf.AddPage()
-
-	return pdf.WithPDF(gpdf)
+// Deprecated: Use New. Kept for backwards compatibility; supplies a nil
+// fonts cache, which is fine as long as HeaderFunc/FooterFunc don't try to
+// load fonts through it.
+func WithGoPdf(ctx context.Context, c Config) pdf.Option {
+	return pdf.WithPDF(New(ctx, c, nil))
 }

--- a/gopdf/text.go
+++ b/gopdf/text.go
@@ -1,0 +1,57 @@
+package gopdf
+
+import (
+	"strings"
+
+	"github.com/signintech/gopdf"
+)
+
+// splitWords splits text into alternating non-space and whitespace runs.
+// Each run is one chunk; the renderer wraps between chunks.
+func splitWords(text string) []string {
+	var chunks []string
+	var buf strings.Builder
+	inSpace := false
+	for i, r := range text {
+		if i == 0 {
+			inSpace = r == ' '
+			buf.WriteRune(r)
+			continue
+		}
+		isSpace := r == ' '
+		if isSpace != inSpace {
+			chunks = append(chunks, buf.String())
+			buf.Reset()
+			inSpace = isSpace
+		}
+		buf.WriteRune(r)
+	}
+	if buf.Len() > 0 {
+		chunks = append(chunks, buf.String())
+	}
+	return chunks
+}
+
+// breakAtWidth returns the largest rune-aligned prefix of s that fits in w,
+// plus the remainder. Always returns at least one rune in head (or, when w is
+// non-positive, the whole string in tail) so callers won't loop forever.
+func breakAtWidth(gpdf *gopdf.GoPdf, s string, w float64) (head, tail string) {
+	runes := []rune(s)
+	if len(runes) == 0 {
+		return "", ""
+	}
+	if w <= 0 {
+		return "", s
+	}
+
+	var line []rune
+	for i, r := range runes {
+		candidate := append(line, r) //nolint:gocritic // we reassign line below; aliasing is intentional
+		cw, _ := gpdf.MeasureTextWidth(string(candidate))
+		if cw > w && len(line) > 0 {
+			return string(line), string(runes[i:])
+		}
+		line = candidate
+	}
+	return string(line), ""
+}

--- a/gopdf/text_test.go
+++ b/gopdf/text_test.go
@@ -1,0 +1,117 @@
+package gopdf
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitWords(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single word", "hello", []string{"hello"}},
+		{"single space", " ", []string{" "}},
+		{"two words", "hello world", []string{"hello", " ", "world"}},
+		{"leading space", " hello", []string{" ", "hello"}},
+		{"trailing space", "hello ", []string{"hello", " "}},
+		{"multiple spaces between", "a   b", []string{"a", "   ", "b"}},
+		{"three words", "one two three", []string{"one", " ", "two", " ", "three"}},
+		{"all spaces", "   ", []string{"   "}},
+		// Only ' ' splits — tabs and newlines stay inside chunks.
+		{"tab is not a split", "a\tb", []string{"a\tb"}},
+		{"newline is not a split", "a\nb", []string{"a\nb"}},
+		{"unicode word", "héllo wörld", []string{"héllo", " ", "wörld"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitWords(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("splitWords(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Exact (head, tail) outputs for the trivial cases.
+func TestBreakAtWidth_ExactOutputs(t *testing.T) {
+	impl := newFontedImpl(t)
+	xWidth := impl.MeasureTextWidth("X")
+
+	cases := []struct {
+		name           string
+		s              string
+		w              float64
+		wantHead, want string
+	}{
+		{"empty", "", 100, "", ""},
+		{"zero width", "hello", 0, "", "hello"},
+		{"negative width", "hello", -1, "", "hello"},
+		{"fits entirely", "hi", 10000, "hi", ""},
+		// Single overflowing rune still comes back as head — the "always make
+		// progress" guarantee so callers don't loop forever.
+		{"single rune overflow", "X", xWidth / 2, "X", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			head, tail := breakAtWidth(impl.GoPdf, tc.s, tc.w)
+			if head != tc.wantHead || tail != tc.want {
+				t.Errorf("got (%q, %q), want (%q, %q)", head, tail, tc.wantHead, tc.want)
+			}
+		})
+	}
+}
+
+// For any positive width and non-empty input, head+tail must reconstruct the
+// input exactly and head must be non-empty (forward progress).
+func TestBreakAtWidth_NoRuneLoss(t *testing.T) {
+	impl := newFontedImpl(t)
+
+	inputs := []string{
+		"the quick brown fox jumps over the lazy dog",
+		"café naïve", // multi-byte runes — must not split mid-rune
+		"aaaaaaaaaaaaaaaaaaaa",
+	}
+
+	for _, s := range inputs {
+		full := impl.MeasureTextWidth(s)
+		for _, frac := range []float64{0.1, 0.25, 0.5, 0.75, 0.9} {
+			w := full * frac
+			head, tail := breakAtWidth(impl.GoPdf, s, w)
+			if head+tail != s {
+				t.Errorf("s=%q frac=%v: head+tail=%q, want %q", s, frac, head+tail, s)
+			}
+			if head == "" {
+				t.Errorf("s=%q frac=%v: head empty for positive width", s, frac)
+			}
+		}
+	}
+}
+
+// When head has more than one rune, its width must actually fit the budget —
+// the loop only emits an over-width head when forced to (single rune).
+func TestBreakAtWidth_HeadFitsWidth(t *testing.T) {
+	impl := newFontedImpl(t)
+	const s = "aaaaaaaaaaaaaaaaaaaa"
+
+	w := impl.MeasureTextWidth(s) / 3
+	head, _ := breakAtWidth(impl.GoPdf, s, w)
+	if headW := impl.MeasureTextWidth(head); headW > w && len([]rune(head)) > 1 {
+		t.Errorf("head %q (width %v) exceeds budget %v with >1 rune", head, headW, w)
+	}
+}
+
+// newFontedImpl returns an *Impl with a font loaded and selected, so
+// MeasureTextWidth works. Skips when no system TTF is available.
+func newFontedImpl(t *testing.T) *Impl {
+	t.Helper()
+	_, impl := newTestPDF(t)
+	if err := impl.SetFont("DejaVu", "", 12); err != nil {
+		t.Fatalf("SetFont: %v", err)
+	}
+	return impl
+}

--- a/pdf.go
+++ b/pdf.go
@@ -20,6 +20,8 @@ type PDF interface {
 
 	SetMarginLeft(margin float64)
 	SetMarginRight(margin float64)
+	SetMarginTop(margin float64)
+	SetMarginBottom(margin float64)
 	GetMargins() (left, top, right, bottom float64)
 
 	// Font
@@ -53,8 +55,7 @@ type PDF interface {
 
 	// Width
 	SetLineWidth(width float64)
-	Line(x1, x2, y1, y2 float64)
-	// Rect(x1, x2, y1, y2 float64)
+	Line(x1, y1, x2, y2 float64)
 
 	// Circle draws a circle centered at (x, y) with radius r, filled with the
 	// current fill color. Backends that can't fill should stroke an outline.

--- a/pdf_test.go
+++ b/pdf_test.go
@@ -37,6 +37,8 @@ func (m *MockPdf) AddFont(family, style string, data []byte) error { return nil 
 func (m *MockPdf) SetLineWidth(width float64)                      {}
 func (m *MockPdf) SetMarginLeft(margin float64)                    {}
 func (m *MockPdf) SetMarginRight(margin float64)                   {}
+func (m *MockPdf) SetMarginTop(margin float64)                     {}
+func (m *MockPdf) SetMarginBottom(margin float64)                  {}
 func (m *MockPdf) SetTextColor(r, g, b uint8)                      {}
 func (m *MockPdf) SetX(x float64)                                  {}
 func (m *MockPdf) SetY(y float64)                                  {}


### PR DESCRIPTION
Currently marked as draft PR to provide transparency. Some tasks are still remaining in the `goals`.

Seems like the `gopdf` has better unicode support and a few other advantages. The drawback is we need to re-implement some of the things that `fpdf` provided. The longer term advantage is it makes it a bit easier to do exactly what we want with `gopdf`.

The pros/cons is pure speculation on my part as to the original motivation in the `README`. Somewhat selfishly, it seems like switching to `gopdf` is easier now than later when the number of features might be greater. I plan on potentially 

## Goals
- [x] small fpdf refactor to make API somewhat closer for both backends
- [x] implement all the TODOs for `gopdf` backend to have basic implementation working
- [x] investigate using the native table rendering from `gopdf` instead of what we did in `fpdf`
- [x] investigate header/footer func equivalent and logo for `gopdf`

## Notes
- seems like our current table implementation is more robust compared to the `gopdf` implentation (ie. per row height computation, automatic page break, etc.)

## Caveats
- This isn't trying to be 1:1 compatibility with `fpdf`, just enough to start using internally and start comparing both implementations (`fpdf` vs `gopdf`)