### PR TITLE
Fix horizontal rules rendering draw color

### DIFF
--- a/fpdf.go
+++ b/fpdf.go
@@ -215,9 +215,7 @@ func (f Fpdf) SetLineWidth(width float64) {
 }
 
 func (f Fpdf) Line(x1 float64, y1 float64, x2 float64, y2 float64) {
-	f.Fpdf.MoveTo(x1, y1)
-	f.Fpdf.LineTo(x2, y2)
-	f.Fpdf.DrawPath("F")
+	f.Fpdf.Line(x1, y1, x2, y2)
 }
 
 func (f Fpdf) Write(w io.Writer) error {

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -452,21 +452,28 @@ func (r *nodeRederFuncs) renderThematicBreak(w *Writer, source []byte, node ast.
 	w.LogDebug("HorizontalRule", "")
 
 	LH := w.States.peek().textStyle.Size + w.States.peek().textStyle.Spacing
+	lineWidth := 3.0
 
 	// do a newline
 	w.Pdf.BR(LH)
-	// get the current x and y (assume left margin in ok)
-	x := w.Pdf.GetX()
-	y := w.Pdf.GetY()
+
 	// get the page margins
 	_, _, rm, _ := w.Pdf.GetMargins()
 	// get the page size
 	width, _ := w.Pdf.GetPageSize()
+
+	// get the current x and y (assume left margin in ok)
+	x := w.Pdf.GetX()
+
+	// Center the rule in the next line of whitespace so the gap above
+	// and below it is roughly equal.
+	y := w.Pdf.GetY() + LH/2 + lineWidth/2
+
 	// now compute the x value of the right side of page
 	newx := width - rm
 
-	w.Pdf.SetLineWidth(3)
-	w.Pdf.SetFillColor(200, 200, 200)
+	w.Pdf.SetLineWidth(lineWidth)
+	w.Pdf.SetDrawColor(200, 200, 200) // Line() strokes with the draw color.
 
 	w.LogDebug("... From X,Y", fmt.Sprintf("%v,%v", x, y))
 	w.Pdf.Line(x, y, newx, y)


### PR DESCRIPTION
The draw color is what needs to be set. Also vertically center the line in the middle of the line when drawing it.

**After the fix in examples**

<img width="737" height="344" alt="image" src="https://github.com/user-attachments/assets/30e80f2c-5025-4a8b-b1d3-bbda7848a9a8" />

Closes #12