### PR TITLE
Implement list item bullet rendering

### DIFF
--- a/examples/overview.md
+++ b/examples/overview.md
@@ -54,6 +54,25 @@ Nested mix (bullets under numbers):
    1. Nested numbered
    2. Another nested numbered
 
+Tight vs. loose: per CommonMark, a list with no blank lines between items is
+*tight* (items separated by a single line height, like the CSS default).
+A list with blank lines between items is *loose* (paragraph-style gap
+between items).
+
+Tight (no blank lines in source):
+
+- Apples
+- Oranges
+- Pears
+
+Loose (blank lines between items):
+
+- Apples
+
+- Oranges
+
+- Pears
+
 ## Blockquotes
 
 > A blockquote is rendered with the `Blockquote` style from

--- a/fpdf.go
+++ b/fpdf.go
@@ -218,6 +218,10 @@ func (f Fpdf) Line(x1 float64, y1 float64, x2 float64, y2 float64) {
 	f.Fpdf.Line(x1, y1, x2, y2)
 }
 
+func (f Fpdf) Circle(x, y, r float64) {
+	f.Fpdf.Circle(x, y, r, "F")
+}
+
 func (f Fpdf) Write(w io.Writer) error {
 	// write the internal links
 	for _, link := range f.anchorLinks {

--- a/gopdf/gopdf.go
+++ b/gopdf/gopdf.go
@@ -252,6 +252,13 @@ func (f Impl) Line(x1 float64, y1 float64, x2 float64, y2 float64) {
 	f.GoPdf.Line(x1, y1, x2, y2)
 }
 
+func (f Impl) Circle(x, y, r float64) {
+	// Oval is stroke-only, so we fake a fill with a stroked band: path-radius r/2 stroked at line width
+	// r yields a band from the center out to full radius r (inner hole = r/2 - r/2 = 0).
+	f.GoPdf.SetLineWidth(r)
+	f.GoPdf.Oval(x-r/2, y-r/2, x+r/2, y+r/2)
+}
+
 func (f Impl) Write(w io.Writer) error {
 	_, err := f.GoPdf.WriteTo(w)
 	return err

--- a/pdf.go
+++ b/pdf.go
@@ -56,6 +56,10 @@ type PDF interface {
 	Line(x1, x2, y1, y2 float64)
 	// Rect(x1, x2, y1, y2 float64)
 
+	// Circle draws a circle centered at (x, y) with radius r, filled with the
+	// current fill color. Backends that can't fill should stroke an outline.
+	Circle(x, y, r float64)
+
 	// Rendering
 	Write(io.Writer) error
 }

--- a/pdf_test.go
+++ b/pdf_test.go
@@ -24,6 +24,7 @@ func (m *MockPdf) GetPageSize() (width, height float64) {
 func (m *MockPdf) GetX() float64               { return 0 }
 func (m *MockPdf) GetY() float64               { return 0 }
 func (m *MockPdf) Line(x1, x2, y1, y2 float64) {}
+func (m *MockPdf) Circle(x, y, r float64)      {}
 func (m *MockPdf) MeasureTextWidth(s string) float64 {
 	// Simple approximation: each character is 5 units wide
 	return float64(len(s)) * 5.0

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -400,9 +400,11 @@ func (r *nodeRederFuncs) renderListItem(w *Writer, source []byte, node ast.Node,
 			w.Pdf.Circle(cx, cy, radius)
 			w.Pdf.SetX(startX + em)
 		} else if w.States.peek().listkind == ordered {
+			// Right-align so the "." sits close to the text, matching the
+			// optical spacing of the centered bullet for unordered lists.
 			w.Pdf.CellFormat(em, w.States.peek().textStyle.Size+w.States.peek().textStyle.Spacing,
-				fmt.Sprintf("%v.", w.States.peek().itemNumber),
-				"", 0, "L", false, 0, "")
+				fmt.Sprintf("%v. ", w.States.peek().itemNumber),
+				"", 0, "R", false, 0, "")
 		}
 
 		w.Pdf.SetMarginLeft(w.States.peek().leftMargin + em)

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -122,6 +122,12 @@ func (r *nodeRederFuncs) renderHeading(w *Writer, source []byte, node ast.Node, 
 func (r *nodeRederFuncs) renderTextBlock(w *Writer, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
 		w.LogDebug("Text Block", "")
+		// Inside a tight list item the list-item leave owns the vertical
+		// advance — emitting a BR here would double-advance and visually
+		// loosen tight lists. Skip it for that case only.
+		if w.States.peek().containerType == ast.KindListItem {
+			return ast.WalkContinue, nil
+		}
 		if node.FirstChild() != nil {
 			w.Pdf.BR(w.States.peek().textStyle.Size + w.States.peek().textStyle.Spacing)
 		}
@@ -335,6 +341,7 @@ func (r *nodeRederFuncs) renderList(w *Writer, source []byte, node ast.Node, ent
 			textStyle:     *w.Styles.Normal, itemNumber: 0,
 			listkind:   kind,
 			leftMargin: w.States.peek().leftMargin,
+			tightList:  n.IsTight,
 		}
 
 		w.Pdf.BR(LH)
@@ -371,6 +378,7 @@ func (r *nodeRederFuncs) renderListItem(w *Writer, source []byte, node ast.Node,
 			listkind:       w.States.peek().listkind,
 			firstParagraph: true,
 			leftMargin:     X,
+			tightList:      w.States.peek().tightList,
 		}
 		w.States.push(x)
 
@@ -378,11 +386,21 @@ func (r *nodeRederFuncs) renderListItem(w *Writer, source []byte, node ast.Node,
 		// text/paragraphs in the item
 		SetStyle(w.Pdf, w.States.peek().textStyle)
 		if w.States.peek().listkind == unordered {
-			w.Pdf.CellFormat(em, w.Styles.Normal.Size+w.Styles.Normal.Spacing,
-				"-",
-				"", 0, "L", false, 0, "")
+			// Draw a filled circle as the bullet. Avoids relying on a "•"  glyph being present in the active font.
+			lh := w.States.peek().textStyle.Size + w.States.peek().textStyle.Spacing
+			radius := w.States.peek().textStyle.Size / 6 // diameter ≈ Size/3, matching a typical "•" glyph
+			red, green, blue, _ := w.States.peek().textStyle.TextColor.RGBA()
+
+			startX := w.Pdf.GetX()
+			cx := startX + em/2
+			cy := w.Pdf.GetY() + lh/2
+
+			w.Pdf.SetFillColor(uint8(red>>8), uint8(green>>8), uint8(blue>>8))
+			w.Pdf.SetDrawColor(uint8(red>>8), uint8(green>>8), uint8(blue>>8))
+			w.Pdf.Circle(cx, cy, radius)
+			w.Pdf.SetX(startX + em)
 		} else if w.States.peek().listkind == ordered {
-			w.Pdf.CellFormat(em, w.Styles.Normal.Size+w.Styles.Normal.Spacing,
+			w.Pdf.CellFormat(em, w.States.peek().textStyle.Size+w.States.peek().textStyle.Spacing,
 				fmt.Sprintf("%v.", w.States.peek().itemNumber),
 				"", 0, "L", false, 0, "")
 		}
@@ -393,7 +411,14 @@ func (r *nodeRederFuncs) renderListItem(w *Writer, source []byte, node ast.Node,
 		w.LogDebug(fmt.Sprintf("%v Item (leaving)", w.States.peek().listkind), "")
 		// before we output the new line, reset left margin
 		w.Pdf.SetMarginLeft(w.States.peek().leftMargin)
-		w.Pdf.BR(w.States.peek().textStyle.Size + w.States.peek().textStyle.Spacing)
+		lh := w.States.peek().textStyle.Size + w.States.peek().textStyle.Spacing
+		if w.States.peek().tightList {
+			// Tight list: items separated by a single line height (CSS default).
+			w.Pdf.BR(lh)
+		} else {
+			// Loose list: paragraph-style gap between items (extra blank line).
+			w.Pdf.BR(lh * 2)
+		}
 		w.States.parent().itemNumber++
 		w.States.pop()
 	}

--- a/state.go
+++ b/state.go
@@ -10,7 +10,8 @@ type state struct {
 
 	// populated if node type is a list
 	listkind   listType
-	itemNumber int // only if an ordered list
+	itemNumber int  // only if an ordered list
+	tightList  bool // true if the containing list is a CommonMark "tight" list
 
 	// populated if node type is a link
 	destination string


### PR DESCRIPTION
The implementation also adds a loose/tight distinction to conform to CommonMark distinction and render accordingly.

To avoid issues with the specified font not actually including the 'bullet' glyph, we instead draw a bullet directly.

## Example

<img width="751" height="900" alt="image" src="https://github.com/user-attachments/assets/8ff01ceb-bfe1-4c5b-ad9e-4a0ae053572d" />

_Overview example in the fpdf rendering backend._

## Notes
- A `Circle()` drawing was added to enable drawing the circle
  - no primitive available in pdf spec
  - used Circle since it is in `fpdf` and `svg` drawing primitive
- The bullet is drawn explicitly instead of using a glyph from font (doesn't rely on font having the glyph)
- Allows to override of the unordered bullet style in the future if we want

Closes #18 