### PR TITLE
Handle soft-line breaks

### DIFF
--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -135,9 +135,17 @@ func (r *nodeRederFuncs) renderText(w *Writer, source []byte, node ast.Node, ent
 		return ast.WalkContinue, nil
 	}
 
+	// Soft line breaks (a bare newline in the source between inline content)
+	// aren't part of the segment value — goldmark exposes them via a flag.
+	// CommonMark renders them as a space when reflowing inline text, so we
+	// append one. Without this, content like "[link](url)\nnext word" runs
+	// the two together as "linknext".
 	n := node.(*ast.Text)
-	segment := n.Segment
-	w.WriteText(string(segment.Value(source)))
+	text := string(n.Segment.Value(source))
+	if n.SoftLineBreak() {
+		text += " "
+	}
+	w.WriteText(text)
 
 	return ast.WalkContinue, nil
 }


### PR DESCRIPTION
In the `overview.md` you can see an explicit newline in the source markdown incorrectly drops the space between the link and the next word. Goldmark already detects if a softline wrap should be used and returns it in the AST.

The fix just adds a space when this is the case.

## Example

The ``[`sample.md`](./sample.md)\nfor`` in the markdown doesn't currently render correctly without the fix.

```md

See [`tables.md`](./tables.md) for table rendering and [`sample.md`](./sample.md)
for a longer end-to-end document.

```

**Before**
<img width="599" height="93" alt="image" src="https://github.com/user-attachments/assets/ae24130e-f825-4925-b2ef-97449d35ee20" />

**After**
<img width="609" height="92" alt="image" src="https://github.com/user-attachments/assets/82d5eda2-c7cb-46eb-98ad-8ab778f71eae" />
