### PR TITLE
Center image caption under the image and make the caption more subtle

### DIFF
--- a/examples/overview.md
+++ b/examples/overview.md
@@ -117,6 +117,13 @@ usage: cbench.py [-h] -cpp CPP [-hwroot HWROOT] [-rundir RUNDIR] [-plusArgsVlog 
                  [-disableSelfCheck] [-nocomp] [-dump] [-iss] [-rtl_syn] [-rtl_fpga]
 ```
 
+## Images
+
+Images can be loaded from a remote URL. The Markdown alt text doubles as a caption beneath the image:
+
+![A mountain landscape (Lorem Picsum stock photo id 1015).](https://picsum.photos/id/1015/640/360.jpg)
+
+
 ## Horizontal rule
 
 A `---` on its own line draws a horizontal rule:

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -3,6 +3,7 @@ package pdf
 import (
 	"bytes"
 	"fmt"
+	"image/color"
 	"io"
 	"log"
 	"strings"
@@ -617,6 +618,33 @@ func (r *nodeRederFuncs) renderImage(w *Writer, source []byte, node ast.Node, en
 			mimeType := getFileMime(imgFile)
 			w.Pdf.RegisterImage(imgPath, getImageMime(mimeType), imgFile)
 			w.Pdf.UseImage(imgPath, mleft*2, w.Pdf.GetY(), maxw, 0)
+
+			// Concatenates the text content of an inline node's descendants.
+			// Used to build a plain-text caption from an image's alt-text children.
+			var altTextBuf bytes.Buffer
+			_ = ast.Walk(n, func(c ast.Node, entering bool) (ast.WalkStatus, error) {
+				if entering {
+					if t, ok := c.(*ast.Text); ok {
+						altTextBuf.Write(t.Segment.Value(source))
+					}
+				}
+
+				return ast.WalkContinue, nil
+			})
+
+			// Render the alt text as an italic, centered caption
+			// under the image, then skip children so the default inline
+			// walker doesn't redraw it left-aligned at the page margin.
+			if altTextBuf.String() != "" {
+				capStyle := *w.Styles.Normal
+				capStyle.format += "I"
+				capStyle.TextColor = color.RGBA{R: 100, G: 100, B: 100, A: 255}
+				SetStyle(w.Pdf, capStyle)
+				w.Pdf.SetX(mleft * 2)
+				w.Pdf.CellFormat(maxw, capStyle.Size+capStyle.Spacing, altTextBuf.String(), "", 1, "C", false, 0, "")
+				SetStyle(w.Pdf, w.States.peek().textStyle)
+			}
+			return ast.WalkSkipChildren, nil
 		} else {
 			log.Printf("IMAGE ERROR: %s, %v", imgPath, err)
 			w.LogDebug("Image (file error)", err.Error())


### PR DESCRIPTION
**Before**
<img width="736" height="483" alt="image" src="https://github.com/user-attachments/assets/71d0ceff-dbaa-4a73-9699-24bc45ecc8c5" />

**After**
<img width="736" height="497" alt="image" src="https://github.com/user-attachments/assets/9e5a6891-6af5-46f9-a725-a8dc0298a943" />

Closes #6