### PR TITLE
Breaking: Switch to using slog for all logging operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ type Config struct {
 	// A cache for the fonts
 	FontsCache fonts.Cache
 
-	// For debugging
-	TraceWriter io.Writer
+	// Receives trace/warning events. nil disables logging.
+	Logger *slog.Logger
 
 	NodeRenderers util.PrioritizedSlice
 }
@@ -66,7 +66,7 @@ An example with some more options:
 goldmark.New(
     goldmark.WithRenderer(
         pdf.New(
-            pdf.WithTraceWriter(os.Stdout),
+            pdf.WithLogger(slog.Default()),
             pdf.WithContext(context.Background()),
             pdf.WithImageFS(os.DirFS(".")),
             pdf.WithLinkColor("cc4578"),
@@ -84,9 +84,39 @@ goldmark.New(
 
 ### HTML escaping
 
-By default. the renderer HTML-escapes literal text, which means characters like `<`, `>`, and `&` are written into the PDF as `&lt;`, `&gt;`, `&amp;` — the right thing for an HTML document but visible noise in a PDF. 
+By default, the renderer HTML-escapes literal text, which means characters like `<`, `>`, and `&` are written into the PDF as `&lt;`, `&gt;`, `&amp;` — the right thing for an HTML document but visible noise in a PDF. 
 
 Pass `pdf.WithEscapeHTML(false)` to emit those characters as-is. This is what you want when the source contains inline code or fenced blocks with HTML-like content, e.g. `` `<strong>bold</strong>` `` should appear with its angle brackets intact rather than as `&lt;strong&gt;bold&lt;/strong&gt;`.
+
+### Logging
+
+The renderer emits two kinds of events through `log/slog`:
+
+- **Debug** — verbose AST-walk trace (one record per node enter/leave), useful for diagnosing layout issues. Each record carries `msg` (detail) and `depth` (stack depth) attributes.
+- **Warn** — recoverable problems such as a missing image. The PDF is still produced; the warning lets the caller know something was skipped.
+
+Logging is opt-in. By default `Config.Logger` is `nil` and both `LogDebug` and `LogWarn` are no-ops, so nothing is written to stderr unless you ask for it.
+
+To opt in, pass `pdf.WithLogger(...)` with the slog logger you want to route events through:
+
+```go
+// Use the process-wide slog default (writes Info+ to stderr by default).
+pdf.WithLogger(slog.Default())
+
+// Or build a dedicated logger — e.g. JSON to a file, with Warn level filtering.
+logger := slog.New(slog.NewJSONHandler(f, &slog.HandlerOptions{Level: slog.LevelWarn}))
+pdf.WithLogger(logger)
+```
+
+The Debug records are emitted for every node enter/leave, so a real document produces thousands of them. Most callers only care about warnings — restrict the handler's level to drop the trace noise:
+
+```go
+// Only surface warnings (e.g. missing images); ignore the AST-walk trace.
+logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+    Level: slog.LevelWarn,
+}))
+pdf.WithLogger(logger)
+```
 
 ## Fonts
 

--- a/config.go
+++ b/config.go
@@ -3,7 +3,7 @@ package pdf
 import (
 	"context"
 	goldrender "github.com/yuin/goldmark/renderer"
-	"io"
+	"log/slog"
 	"net/http"
 	"os"
 
@@ -26,8 +26,10 @@ type Config struct {
 	// A cache for the fonts
 	FontsCache fonts.Cache
 
-	// For debugging
-	TraceWriter io.Writer
+	// Logger receives trace and warning events from the renderer. A nil
+	// Logger disables all logging — use WithLogger(slog.Default()) (or any
+	// configured logger) to enable.
+	Logger *slog.Logger
 
 	NodeRenderers util.PrioritizedSlice
 }

--- a/option.go
+++ b/option.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	goldrender "github.com/yuin/goldmark/renderer"
 	"image/color"
-	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/alecthomas/chroma/v2"
@@ -67,10 +67,12 @@ func WithLinkColor(val color.Color) Option {
 	})
 }
 
-// Provide an io.Write where debug information will be written to
-func WithTraceWriter(val io.Writer) Option {
+// WithLogger sets the slog.Logger used by the renderer for trace and warning
+// events (e.g. missing images). Pass nil (or omit the option entirely) to
+// disable logging.
+func WithLogger(l *slog.Logger) Option {
 	return OptionFunc(func(c *Config) {
-		c.TraceWriter = val
+		c.Logger = l
 	})
 }
 

--- a/renderer.go
+++ b/renderer.go
@@ -53,7 +53,7 @@ func (r *renderer) Register(kind ast.NodeKind, v NodeRendererFunc) {
 	}
 }
 
-// Render renders the given AST node to the given writer.
+// Render the given AST node to the given writer.
 func (r *renderer) Render(w io.Writer, source []byte, n ast.Node) error {
 	r.initSync.Do(func() {
 		// r.options = r.config.Options
@@ -97,12 +97,12 @@ func (r *renderer) Render(w io.Writer, source []byte, n ast.Node) error {
 	}
 
 	writer := &Writer{
-		Pdf:         pdf,
-		ImageFS:     mergeFs(r.config.ImageFS, &inlineFs{}, &webFs{}),
-		Styles:      r.config.Styles,
-		DebugWriter: r.config.TraceWriter,
-		States:      states{stack: make([]*state, 0)},
-		EscapeHTML:  escapeHTML,
+		Pdf:        pdf,
+		ImageFS:    mergeFs(r.config.ImageFS, &inlineFs{}, &webFs{}),
+		Styles:     r.config.Styles,
+		Logger:     r.config.Logger,
+		States:     states{stack: make([]*state, 0)},
+		EscapeHTML: escapeHTML,
 	}
 
 	mleft, _, _, _ := pdf.GetMargins()

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image/color"
 	"io"
-	"log"
 	"strings"
 
 	"github.com/alecthomas/chroma/v2"
@@ -645,10 +644,9 @@ func (r *nodeRederFuncs) renderImage(w *Writer, source []byte, node ast.Node, en
 				SetStyle(w.Pdf, w.States.peek().textStyle)
 			}
 			return ast.WalkSkipChildren, nil
-		} else {
-			log.Printf("IMAGE ERROR: %s, %v", imgPath, err)
-			w.LogDebug("Image (file error)", err.Error())
 		}
+
+		w.LogWarn("Image (internal)", fmt.Sprintf("%q: %v", imgPath, err))
 	} else {
 		w.LogDebug("Image (leaving)", "")
 	}

--- a/writer.go
+++ b/writer.go
@@ -3,9 +3,9 @@ package pdf
 import (
 	"bufio"
 	"bytes"
-	"fmt"
+	"context"
 	"image/color"
-	"io"
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -22,16 +22,34 @@ type Writer struct {
 	Styles  Styles
 	States  states
 
-	EscapeHTML  bool
-	DebugWriter io.Writer
+	EscapeHTML bool
+	// Logger receives trace and warning events from the renderer. A nil
+	// Logger disables all logging — set one to opt in.
+	Logger *slog.Logger
 }
 
-// To log debug information. Nothing is logged if DebugWriter is nil
+// LogDebug emits a debug trace event with the source as the slog message and
+// a "msg" attribute carrying the details. If no Logger is configured the call
+// is dropped — debug trace is opt-in.
 func (r *Writer) LogDebug(source, msg string) {
-	if r.DebugWriter != nil {
-		indent := strings.Repeat("-", len(r.States.stack)-1)
-		_, _ = fmt.Fprintf(r.DebugWriter, "%v[%v] %v\n", indent, source, msg)
+	if r.Logger == nil {
+		return
 	}
+	r.Logger.LogAttrs(context.Background(), slog.LevelDebug, source,
+		slog.String("msg", msg),
+		slog.Int("depth", len(r.States.stack)-1),
+	)
+}
+
+// LogWarn reports a recoverable problem (e.g. a missing image) at slog warn
+// level. A nil Logger disables the message — opt in by passing WithLogger.
+func (r *Writer) LogWarn(source, msg string) {
+	if r.Logger == nil {
+		return
+	}
+	r.Logger.LogAttrs(context.Background(), slog.LevelWarn, source,
+		slog.String("msg", msg),
+	)
 }
 
 // Write a string with a given style

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,114 @@
+package pdf
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/yuin/goldmark"
+)
+
+// captureHandler collects slog records for inspection in tests.
+type captureHandler struct {
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// writerWithStack returns a Writer whose state stack has the given depth
+// (the LogDebug `depth` attribute is len(stack)-1).
+func writerWithStack(depth int) *Writer {
+	w := &Writer{}
+	for i := 0; i <= depth; i++ {
+		w.States.push(&state{})
+	}
+	return w
+}
+
+// TestWriterLogging_NilLoggerIsNoOp verifies that with a nil logger neither
+// LogDebug nor LogWarn panics or emits anywhere.
+func TestWriterLogging_NilLoggerIsNoOp(t *testing.T) {
+	w := writerWithStack(0)
+	w.LogDebug("debug source", "details")
+	w.LogWarn("warn source", "details")
+}
+
+// TestWriterLogging_EmitsThroughLogger verifies that with a logger configured
+// both helpers route records to it at the expected level.
+func TestWriterLogging_EmitsThroughLogger(t *testing.T) {
+	h := &captureHandler{}
+	w := writerWithStack(0)
+	w.Logger = slog.New(h)
+
+	w.LogDebug("Paragraph", "entering")
+	w.LogWarn("missing image", "details")
+
+	if len(h.records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(h.records))
+	}
+	if h.records[0].Level != slog.LevelDebug || h.records[0].Message != "Paragraph" {
+		t.Errorf("debug record = %v/%q, want Debug/Paragraph", h.records[0].Level, h.records[0].Message)
+	}
+	if h.records[1].Level != slog.LevelWarn || h.records[1].Message != "missing image" {
+		t.Errorf("warn record = %v/%q, want Warn/missing image", h.records[1].Level, h.records[1].Message)
+	}
+}
+
+// TestRender_MissingImageWarns drives a full markdown render that references
+// an image not present in the configured FS, and asserts the renderer emits a
+// Warn record naming the missing path.
+func TestRender_MissingImageWarns(t *testing.T) {
+	h := &captureHandler{}
+	logger := slog.New(h)
+
+	md := goldmark.New(
+		goldmark.WithRenderer(New(
+			WithPDF(&MockPdf{pageWidth: 600, pageHeight: 800, leftMargin: 50, rightMargin: 50}),
+			WithImageFS(http.FS(fstest.MapFS{})), // empty FS so any lookup fails
+			WithLogger(logger),
+			// Inbuilt fonts skip the Google-fonts network fetch.
+			WithHeadingFont(FontHelvetica),
+			WithBodyFont(FontHelvetica),
+			WithCodeFont(FontCourier),
+		)),
+	)
+	var buf bytes.Buffer
+	if err := md.Convert([]byte("![alt](nonexistent.png)\n"), &buf); err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+
+	var warn *slog.Record
+	for i := range h.records {
+		if h.records[i].Level == slog.LevelWarn {
+			warn = &h.records[i]
+			break
+		}
+	}
+	if warn == nil {
+		t.Fatalf("expected a Warn record for the missing image, got %d records", len(h.records))
+	}
+	if warn.Message != "Image (internal)" {
+		t.Errorf("warn message = %q, want %q", warn.Message, "Image (internal)")
+	}
+	var msgAttr string
+	warn.Attrs(func(a slog.Attr) bool {
+		if a.Key == "msg" {
+			msgAttr = a.Value.String()
+			return false
+		}
+		return true
+	})
+	if !strings.Contains(msgAttr, "nonexistent.png") {
+		t.Errorf("warn msg attr = %q, want it to mention the missing path", msgAttr)
+	}
+}


### PR DESCRIPTION
Since go `1.21`, `slog` is available. Instead of using the `io.Writer` like before, switch to slog.

Fixes #11 since slog allows you to ignore/specify the log levels you care about. So for #11 with the slog implementation, the user can set a logger to the warn level.