### PR TITLE
Preserve image natural size if smaller than page width

### DIFF
--- a/examples/overview.md
+++ b/examples/overview.md
@@ -133,9 +133,13 @@ usage: cbench.py [-h] -cpp CPP [-hwroot HWROOT] [-rundir RUNDIR] [-plusArgsVlog 
 
 ## Images
 
-Images can be loaded from a remote URL. The Markdown alt text doubles as a caption beneath the image:
+Images can be loaded from a remote URL. The Markdown alt text doubles as a caption beneath the image. Images whose natural dimensions fit within the page's content area are rendered at their natural size — the picture below is 300×200, comfortably smaller than the A4 content width:
 
-![A mountain landscape (Lorem Picsum stock photo id 1015).](https://picsum.photos/id/1015/640/360.jpg)
+![A mountain landscape (Lorem Picsum stock photo id 1015).](https://picsum.photos/id/1015/300/200.jpg)
+
+Images whose natural dimensions exceed the page's content area are scaled down to fit. The picture below is 2000×1500 — roughly four times wider than the A4 content width — and gets shrunk on the way in:
+
+![A lakeside scene (Lorem Picsum stock photo id 1018).](https://picsum.photos/id/1018/2000/1500.jpg)
 
 
 ## Horizontal rule

--- a/fpdf/fpdf.go
+++ b/fpdf/fpdf.go
@@ -178,6 +178,14 @@ func (f Impl) UseImage(imgID string, x, y, w, h float64) {
 	f.Fpdf.ImageOptions(imgID, x, y, w, h, true, gofpdf.ImageOptions{ImageType: "", ReadDpi: false}, 0, "")
 }
 
+func (f Impl) ImageNaturalSize(imgID string) (float64, float64) {
+	info := f.Fpdf.GetImageInfo(imgID)
+	if info == nil {
+		return 0, 0
+	}
+	return info.Width(), info.Height()
+}
+
 // Measuring
 func (f Impl) MeasureTextWidth(text string) float64 {
 	return f.Fpdf.GetStringWidth(sanitizeUnicode(text))

--- a/gopdf/gopdf.go
+++ b/gopdf/gopdf.go
@@ -593,6 +593,13 @@ func (f *Impl) RegisterImage(id string, format string, src io.Reader) {
 	}
 }
 
+func (f *Impl) ImageNaturalSize(imgID string) (float64, float64) {
+	if img, ok := f.images[imgID]; ok {
+		return img.naturalWidth, img.naturalHeight
+	}
+	return 0, 0
+}
+
 func (f *Impl) UseImage(imgID string, x, y, w, h float64) {
 	img, ok := f.images[imgID]
 	if !ok {

--- a/pdf.go
+++ b/pdf.go
@@ -43,6 +43,10 @@ type PDF interface {
 	// Images
 	RegisterImage(id, format string, src io.Reader)
 	UseImage(id string, x, y, w, h float64)
+	// ImageNaturalSize returns a previously registered image's natural
+	// width/height in user units (points, assuming 72 DPI). Returns (0, 0)
+	// if the image is unknown or its dimensions couldn't be determined.
+	ImageNaturalSize(id string) (w, h float64)
 
 	// Measuring
 	MeasureTextWidth(text string) float64

--- a/pdf_test.go
+++ b/pdf_test.go
@@ -60,6 +60,7 @@ func (m *MockPdf) SplitText(txt string, w float64) []string {
 	return lines
 }
 func (m *MockPdf) UseImage(id string, x, y, w, h float64)                           {}
+func (m *MockPdf) ImageNaturalSize(id string) (float64, float64)                    { return 0, 0 }
 func (m *MockPdf) Write(w io.Writer) error                                          { return nil }
 func (m *MockPdf) WriteText(h float64, txtStr string)                               {}
 func (m *MockPdf) WriteInternalLink(lineHeight float64, text string, anchor string) {}

--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -616,7 +616,18 @@ func (r *nodeRederFuncs) renderImage(w *Writer, source []byte, node ast.Node, en
 
 			mimeType := getFileMime(imgFile)
 			w.Pdf.RegisterImage(imgPath, getImageMime(mimeType), imgFile)
-			w.Pdf.UseImage(imgPath, mleft*2, w.Pdf.GetY(), maxw, 0)
+
+			// Honor the image's natural size when it fits within the content
+			// area; only scale down when it would overflow. Smaller images get
+			// horizontally centered within the content area so the caption
+			// (kept at maxw) sits visually under them.
+			drawX := mleft * 2
+			drawW := maxw
+			if naturalW, _ := w.Pdf.ImageNaturalSize(imgPath); naturalW > 0 && naturalW < maxw {
+				drawW = naturalW
+				drawX = mleft*2 + (maxw-naturalW)/2
+			}
+			w.Pdf.UseImage(imgPath, drawX, w.Pdf.GetY(), drawW, 0)
 
 			// Concatenates the text content of an inline node's descendants.
 			// Used to build a plain-text caption from an image's alt-text children.


### PR DESCRIPTION
Closes #5

**Example**
<img width="785" height="435" alt="image" src="https://github.com/user-attachments/assets/1331737e-1c4f-4a92-bc32-fa6fa97038c8" />

