### PR TITLE
Handle string rendering produced by extensions

### DIFF
--- a/renderer_funcs.go
+++ b/renderer_funcs.go
@@ -141,17 +141,25 @@ func (r *nodeRederFuncs) renderText(w *Writer, source []byte, node ast.Node, ent
 		return ast.WalkContinue, nil
 	}
 
-	// Soft line breaks (a bare newline in the source between inline content)
-	// aren't part of the segment value — goldmark exposes them via a flag.
-	// CommonMark renders them as a space when reflowing inline text, so we
-	// append one. Without this, content like "[link](url)\nnext word" runs
-	// the two together as "linknext".
-	n := node.(*ast.Text)
-	text := string(n.Segment.Value(source))
-	if n.SoftLineBreak() {
-		text += " "
+	// Both KindText and KindString are registered to this func. *ast.String
+	// is emitted by extensions (e.g. Typographer's smart-quote/dash/ellipsis
+	// substitutions) and stores its bytes directly on Value rather than via
+	// a source Segment.
+	switch n := node.(type) {
+	case *ast.Text:
+		// Soft line breaks (a bare newline in the source between inline
+		// content) aren't part of the segment value — goldmark exposes them
+		// via a flag. CommonMark renders them as a space when reflowing
+		// inline text, so we append one. Without this, content like
+		// "[link](url)\nnext word" runs the two together as "linknext".
+		text := string(n.Segment.Value(source))
+		if n.SoftLineBreak() {
+			text += " "
+		}
+		w.WriteText(text)
+	case *ast.String:
+		w.WriteText(string(n.Value))
 	}
-	w.WriteText(text)
 
 	return ast.WalkContinue, nil
 }

--- a/renderer_funcs_test.go
+++ b/renderer_funcs_test.go
@@ -1,0 +1,34 @@
+package pdf
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/extension"
+)
+
+// renderText is registered for both KindText and KindString but
+// unconditionally cast to *ast.Text, panicking when an extension emits
+// *ast.String (e.g. Typographer's smart-quote/dash substitutions).
+func TestRender_AstStringDoesNotPanic(t *testing.T) {
+	md := goldmark.New(
+		goldmark.WithExtensions(extension.Typographer),
+		goldmark.WithRenderer(New(
+			WithPDF(&MockPdf{pageWidth: 600, pageHeight: 800, leftMargin: 50, rightMargin: 50}),
+			// Inbuilt fonts skip the Google-fonts network fetch.
+			WithHeadingFont(FontHelvetica),
+			WithBodyFont(FontHelvetica),
+			WithCodeFont(FontCourier),
+		)),
+	)
+
+	// Typographer rewrites the dashes, ellipsis, and quotes into *ast.String
+	// nodes interleaved with the surrounding *ast.Text.
+	const sample = "Hello -- world... and \"quotes\".\n"
+
+	var buf bytes.Buffer
+	if err := md.Convert([]byte(sample), &buf); err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+}


### PR DESCRIPTION
Basically just need to also handle `*ast.String` in the text rendering func.

Fixes #16 